### PR TITLE
Add JDK 7, 9 and 11 to Travis CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: java
 sudo: false
 
 jdk:
+  - oraclejdk11
   - oraclejdk9
   - oraclejdk8
   - openjdk7

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ language: java
 sudo: false
 
 jdk:
+  - oraclejdk9
   - oraclejdk8
+  - openjdk7
 
 install: true
 


### PR DESCRIPTION
In Travis CI [documentation](https://docs.travis-ci.com/user/reference/trusty/#jvm-clojure-groovy-java-scala-images) is said that Oracle JDK 10 is not support:
>Oracle JDK 10 is not provided because it reached End of Life in October 2018.

I tried to include JDK 10 in https://github.com/saeg/jaguar2/commit/4a80327da410ca8628dcdeff293ec0d592490e5f but the build [failed](https://travis-ci.com/saeg/jaguar2/builds/98831073).

OpenJDK 6 in theory is supported using the `openjdk-6-jdk` package add-on. But the commit https://github.com/saeg/jaguar2/commit/cd5e63a59882366c98aa33b577eb9c57580c3be4 shows that the build also [failed](https://travis-ci.com/saeg/jaguar2/builds/98821170).

We can later try to use [jdk_switcher](https://docs.travis-ci.com/user/languages/java/#switching-jdks-java-8-and-below-within-one-job) to intall JDK 6 and 10