### PR TITLE
Hello, SpotBugs

### DIFF
--- a/jaguar-core/src/main/java/br/usp/each/saeg/jaguar/core/heuristic/MinusHeuristic.java
+++ b/jaguar-core/src/main/java/br/usp/each/saeg/jaguar/core/heuristic/MinusHeuristic.java
@@ -26,7 +26,7 @@ public class MinusHeuristic implements Heuristic {
 			minusPassed = (((double) cep / (cep + cnp)));
 		}
 
-		if (minusFailed != 1) {
+		if (Math.abs(minusFailed - 1.0d) >= 0.001) {
 			suspiciousnessMinus = (double) (1 - minusFailed)
 					/ ((1 - minusFailed) + (1 - minusPassed));
 		}

--- a/pom.xml
+++ b/pom.xml
@@ -74,4 +74,28 @@
 		</pluginManagement>
 	</build>
 
+	<profiles>
+		<profile>
+			<activation>
+				<jdk>[1.8,)</jdk>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>com.github.spotbugs</groupId>
+						<artifactId>spotbugs-maven-plugin</artifactId>
+						<version>3.1.10</version>
+						<executions>
+							<execution>
+								<goals>
+									<goal>check</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+
 </project>


### PR DESCRIPTION
SpotBugs requires JRE (or JDK) 1.8.0 or later to run, so it is enabled only for JDK >= 8