### PR TITLE
Hello, Mockito 🍹

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,6 +193,12 @@
 			<version>4.13.2</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>1.10.19</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<profiles>


### PR DESCRIPTION
The Mockito dependency is defined in the parent POM so it will be
available for all modules.

See:

https://site.mockito.org