### PR TITLE
Jaguar entry point

### DIFF
--- a/jaguar2-core/pom.xml
+++ b/jaguar2-core/pom.xml
@@ -25,4 +25,12 @@
 		<license.header.fileLocation>../LICENSE-TEMPLATE.txt</license.header.fileLocation>
 	</properties>
 
+	<dependencies>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>jaguar2-api</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+	</dependencies>
+
 </project>

--- a/jaguar2-core/src/main/java/br/usp/each/saeg/jaguar2/core/Jaguar.java
+++ b/jaguar2-core/src/main/java/br/usp/each/saeg/jaguar2/core/Jaguar.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2021, 2021 University of Sao Paulo and Contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Roberto Araujo - initial API and implementation and/or initial documentation
+ */
+package br.usp.each.saeg.jaguar2.core;
+
+import br.usp.each.saeg.jaguar2.CoverageControllerLoader;
+import br.usp.each.saeg.jaguar2.spi.CoverageController;
+
+public class Jaguar {
+
+    private final CoverageController controller;
+
+    public Jaguar(final CoverageController controller) {
+        this.controller = controller;
+    }
+
+    public Jaguar() {
+        this(new CoverageControllerLoader().load());
+    }
+
+    /**
+     * Called when an atomic test is about to be started.
+     *
+     * The current implementation reset runtime code coverage data as no
+     * code executed so far is related to current test.
+     */
+    public void testStarted() {
+        if (controller != null) {
+            controller.reset();
+        }
+    }
+
+    /**
+     * Called when an atomic test has finished, whether the test succeeds
+     * or fails.
+     *
+     * The current implementation save runtime code coverage data for
+     * further analysis. The data is flagged when executed by a failing
+     * test case.
+     *
+     * @param testFailed a flag indicating that test fails.
+     */
+    public void testFinished(final boolean testFailed) {
+        if (controller != null) {
+            controller.save(testFailed);
+        }
+    }
+
+}

--- a/jaguar2-core/src/test/java/br/usp/each/saeg/jaguar2/core/JaguarTest.java
+++ b/jaguar2-core/src/test/java/br/usp/each/saeg/jaguar2/core/JaguarTest.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2021, 2021 University of Sao Paulo and Contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Roberto Araujo - initial API and implementation and/or initial documentation
+ */
+package br.usp.each.saeg.jaguar2.core;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import br.usp.each.saeg.jaguar2.spi.CoverageController;
+
+@RunWith(MockitoJUnitRunner.class)
+public class JaguarTest {
+
+    @Mock
+    private CoverageController controllerMock;
+
+    private Jaguar jaguar;
+
+    @Before
+    public void setUp() {
+        jaguar = new Jaguar(controllerMock);
+    }
+
+    @Test
+    public void testStartedCallControllerReset() {
+        // When
+        jaguar.testStarted();
+
+        // Then
+        verify(controllerMock, times(1)).reset();
+    }
+
+    @Test
+    public void testFinishSuccessCallControllerResetWithFalse() {
+        // When
+        jaguar.testFinished(false);
+
+        // Then
+        verify(controllerMock, times(1)).save(false);
+    }
+
+    @Test
+    public void testFinishFailCallControllerResetWithTrue() {
+        // When
+        jaguar.testFinished(true);
+
+        // Then
+        verify(controllerMock, times(1)).save(true);
+    }
+
+}


### PR DESCRIPTION
Create Jaguar entry point class. Still work-in-progress, but it will be
useful to start implementing the test listeners and providers.