### PR TITLE
Create Jaguar2 Commons module and class files cache

### DIFF
--- a/jaguar2-commons/.gitignore
+++ b/jaguar2-commons/.gitignore
@@ -1,0 +1,12 @@
+*.class
+/target
+
+# Package Files #
+*.jar
+*.war
+*.ear
+
+# eclipse
+/.classpath
+/.project
+/.settings

--- a/jaguar2-commons/pom.xml
+++ b/jaguar2-commons/pom.xml
@@ -1,0 +1,28 @@
+<!--
+
+    Copyright (c) 2021, 2021 University of Sao Paulo and Contributors.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Roberto Araujo - initial API and implementation and/or initial documentation
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>br.usp.each.saeg</groupId>
+		<artifactId>jaguar2-parent</artifactId>
+		<version>0.0.1-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>jaguar2-commons</artifactId>
+
+	<properties>
+		<license.header.fileLocation>../LICENSE-TEMPLATE.txt</license.header.fileLocation>
+	</properties>
+
+</project>

--- a/jaguar2-commons/src/main/java/br/usp/each/saeg/jaguar2/commons/ClassFiles.java
+++ b/jaguar2-commons/src/main/java/br/usp/each/saeg/jaguar2/commons/ClassFiles.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2021, 2021 University of Sao Paulo and Contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Roberto Araujo - initial API and implementation and/or initial documentation
+ */
+package br.usp.each.saeg.jaguar2.commons;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Utility that cache all .class files from a directory and look up
+ * them based on the VM class name.
+ *
+ * Note: We use the folder structure as the package name and the file
+ * name as class name.
+ */
+public class ClassFiles {
+
+    private static final String DOT_CLASS = ".class";
+
+    private final Map<String, File> classFilesCache = new HashMap<String, File>();
+
+    /**
+     * Utility that cache all .class files from a directory and look up
+     * them based on the VM class name.
+     *
+     * @param classesDir the directory to search for .class files.
+     */
+    public ClassFiles(final File classesDir) {
+        populateClassFilesCache(classesDir, "");
+    }
+
+    private void populateClassFilesCache(final File dir, final String path) {
+        final File[] files = dir.listFiles();
+        if (files == null) {
+            return;
+        }
+        for (final File file : files) {
+            final String name = file.getName();
+            if (file.isDirectory()) {
+                populateClassFilesCache(file, path + name + "/");
+            } else if (name.endsWith(DOT_CLASS)) {
+                final String className = path
+                        + name.substring(0, name.length() - DOT_CLASS.length());
+                classFilesCache.put(className, file);
+            }
+        }
+    }
+
+    /**
+     * Check if cache is empty or not.
+     *
+     * @return <code>true</code> if there is no .class files cached,
+     *         <code>false</code> otherwise.
+     */
+    public boolean isEmpty() {
+        return classFilesCache.isEmpty();
+    }
+
+    /**
+     * Get a {@link File} from a given .class based on the VM class name.
+     *
+     * @param vmClassName the VM class name;
+     *
+     *                    Note: We use the folder structure as the package
+     *                    name and the file name as class name.
+     *
+     * @return a {@link File} from a given .class file of
+     *         <code>null</code> if the class file is not cached.
+     */
+    public File get(final String vmClassName) {
+        return classFilesCache.get(vmClassName);
+    }
+
+}

--- a/jaguar2-commons/src/test/java/br/usp/each/saeg/jaguar2/commons/AbstractClassFilesTest.java
+++ b/jaguar2-commons/src/test/java/br/usp/each/saeg/jaguar2/commons/AbstractClassFilesTest.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2021, 2021 University of Sao Paulo and Contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Roberto Araujo - initial API and implementation and/or initial documentation
+ */
+package br.usp.each.saeg.jaguar2.commons;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+
+public class AbstractClassFilesTest {
+
+    @Rule
+    public final TemporaryFolder folder = new TemporaryFolder();
+
+    protected ClassFiles classFiles;
+
+    @Before
+    public void setUp() {
+        classFiles = new ClassFiles(folder.getRoot());
+    }
+
+    public File newFile(final String fileName, final String... paths) {
+        try {
+            if (paths.length > 0) {
+                final File f = new File(folder.newFolder(paths), fileName);
+                f.createNewFile();
+                return f;
+            } else {
+                return folder.newFile(fileName);
+            }
+        } catch (final IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/jaguar2-commons/src/test/java/br/usp/each/saeg/jaguar2/commons/ClassFilesDirectoryWithOneClassFileTest.java
+++ b/jaguar2-commons/src/test/java/br/usp/each/saeg/jaguar2/commons/ClassFilesDirectoryWithOneClassFileTest.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2021, 2021 University of Sao Paulo and Contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Roberto Araujo - initial API and implementation and/or initial documentation
+ */
+package br.usp.each.saeg.jaguar2.commons;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ClassFilesDirectoryWithOneClassFileTest extends AbstractClassFilesTest {
+
+    @Override
+    public void setUp() {
+        newFile("Some.class");
+        super.setUp();
+    }
+
+    @Test
+    public void testIsEmpty() {
+        Assert.assertFalse(classFiles.isEmpty());
+    }
+
+    @Test
+    public void testSomeClassIsFound() {
+        Assert.assertNotNull(classFiles.get("Some"));
+    }
+
+    @Test
+    public void testAnotherClassIsNotFound() {
+        Assert.assertNull(classFiles.get("Another"));
+    }
+
+}

--- a/jaguar2-commons/src/test/java/br/usp/each/saeg/jaguar2/commons/ClassFilesDirectoryWithPackagesClassFilesTest.java
+++ b/jaguar2-commons/src/test/java/br/usp/each/saeg/jaguar2/commons/ClassFilesDirectoryWithPackagesClassFilesTest.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2021, 2021 University of Sao Paulo and Contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Roberto Araujo - initial API and implementation and/or initial documentation
+ */
+package br.usp.each.saeg.jaguar2.commons;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ClassFilesDirectoryWithPackagesClassFilesTest extends AbstractClassFilesTest {
+
+    @Override
+    public void setUp() {
+        newFile("Some.class");
+        newFile("Another.class");
+        newFile("Foo.class", "foo");
+        newFile("Bar.class", "bar");
+        newFile("FooBar.class", "foo", "bar");
+        super.setUp();
+    }
+
+    @Test
+    public void testIsEmpty() {
+        Assert.assertFalse(classFiles.isEmpty());
+    }
+
+    @Test
+    public void testSomeClassIsFound() {
+        Assert.assertNotNull(classFiles.get("Some"));
+    }
+
+    @Test
+    public void testAnotherClassIsFound() {
+        Assert.assertNotNull(classFiles.get("Another"));
+    }
+
+    @Test
+    public void testPackageFooClassFooIsFound() {
+        Assert.assertNotNull(classFiles.get("foo/Foo"));
+    }
+
+    @Test
+    public void testPackageBarClassBarIsFound() {
+        Assert.assertNotNull(classFiles.get("bar/Bar"));
+    }
+
+    @Test
+    public void testPackageFooNestedPackageBarClassFooBarIsFound() {
+        Assert.assertNotNull(classFiles.get("foo/bar/FooBar"));
+    }
+
+}

--- a/jaguar2-commons/src/test/java/br/usp/each/saeg/jaguar2/commons/ClassFilesDirectoryWithTwoClassFilesTest.java
+++ b/jaguar2-commons/src/test/java/br/usp/each/saeg/jaguar2/commons/ClassFilesDirectoryWithTwoClassFilesTest.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2021, 2021 University of Sao Paulo and Contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Roberto Araujo - initial API and implementation and/or initial documentation
+ */
+package br.usp.each.saeg.jaguar2.commons;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ClassFilesDirectoryWithTwoClassFilesTest extends AbstractClassFilesTest {
+
+    @Override
+    public void setUp() {
+        newFile("Some.class");
+        newFile("Another.class");
+        super.setUp();
+    }
+
+    @Test
+    public void testIsEmpty() {
+        Assert.assertFalse(classFiles.isEmpty());
+    }
+
+    @Test
+    public void testSomeClassIsFound() {
+        Assert.assertNotNull(classFiles.get("Some"));
+    }
+
+    @Test
+    public void testAnotherClassIsFound() {
+        Assert.assertNotNull(classFiles.get("Another"));
+    }
+
+}

--- a/jaguar2-commons/src/test/java/br/usp/each/saeg/jaguar2/commons/ClassFilesEmptyDirectoryTest.java
+++ b/jaguar2-commons/src/test/java/br/usp/each/saeg/jaguar2/commons/ClassFilesEmptyDirectoryTest.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2021, 2021 University of Sao Paulo and Contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Roberto Araujo - initial API and implementation and/or initial documentation
+ */
+package br.usp.each.saeg.jaguar2.commons;
+
+import java.io.IOException;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ClassFilesEmptyDirectoryTest extends AbstractClassFilesTest {
+
+    @Test
+    public void testIsEmpty() throws IOException {
+        Assert.assertTrue(classFiles.isEmpty());
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,7 @@
 	<modules>
 		<module>jaguar2-api</module>
 		<module>jaguar2-core</module>
+		<module>jaguar2-commons</module>
 		<module>jaguar2-junit</module>
 		<module>jaguar2-ba-dua-provider</module>
 		<module>jaguar2-jacoco-provider</module>


### PR DESCRIPTION
This module will contain utility classes that can be used by any other
Jaguar2 module.

Righ now, the only included class is a class files cache that will be
used by JaCoCo and BA-DUA providers.