### PR TITLE
Jaguar2 JaCoCo Provider `analyze` implementation

### DIFF
--- a/jaguar2-commons/pom.xml
+++ b/jaguar2-commons/pom.xml
@@ -25,4 +25,12 @@
 		<license.header.fileLocation>../LICENSE-TEMPLATE.txt</license.header.fileLocation>
 	</properties>
 
+	<dependencies>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>jaguar2-api</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+	</dependencies>
+
 </project>

--- a/jaguar2-commons/src/main/java/br/usp/each/saeg/jaguar2/commons/ClassFilesController.java
+++ b/jaguar2-commons/src/main/java/br/usp/each/saeg/jaguar2/commons/ClassFilesController.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2021, 2021 University of Sao Paulo and Contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Roberto Araujo - initial API and implementation and/or initial documentation
+ */
+package br.usp.each.saeg.jaguar2.commons;
+
+import java.io.File;
+
+import br.usp.each.saeg.jaguar2.spi.CoverageController;
+
+public abstract class ClassFilesController implements CoverageController {
+
+    public static final String JAGUAR2_CLASSES_DIRS_PROPERTY_NAME = "jaguar2.classesDirs";
+
+    protected File[] classesDirs;
+
+    protected ClassFiles classFiles;
+
+    @Override
+    public void init() {
+        classesDirs = getClassesDirs();
+        classFiles = new ClassFiles(classesDirs);
+    }
+
+    @Override
+    public void destroy() {
+        classesDirs = null;
+        classFiles = null;
+    }
+
+    private static File[] getClassesDirs() {
+        final String value = System.getProperty(JAGUAR2_CLASSES_DIRS_PROPERTY_NAME);
+        if (value == null) {
+            return new File[0];
+        }
+        final String[] paths = value.split(File.pathSeparator);
+        final File[] files = new File[paths.length];
+        for (int i = 0; i < paths.length; i++) {
+            files[i] = new File(paths[i]);
+        }
+        return files;
+    }
+
+}

--- a/jaguar2-core/src/main/java/br/usp/each/saeg/jaguar2/core/Jaguar.java
+++ b/jaguar2-core/src/main/java/br/usp/each/saeg/jaguar2/core/Jaguar.java
@@ -11,6 +11,8 @@
 package br.usp.each.saeg.jaguar2.core;
 
 import br.usp.each.saeg.jaguar2.CoverageControllerLoader;
+import br.usp.each.saeg.jaguar2.api.IClassSpectrum;
+import br.usp.each.saeg.jaguar2.api.ISpectrumVisitor;
 import br.usp.each.saeg.jaguar2.spi.CoverageController;
 
 public class Jaguar {
@@ -67,7 +69,11 @@ public class Jaguar {
      */
     public void testRunFinished() {
         if (controller != null) {
-            controller.analyze(null);
+            controller.analyze(new ISpectrumVisitor() {
+                @Override
+                public void visitSpectrum(final IClassSpectrum spectrum) {
+                }
+            });
         }
     }
 

--- a/jaguar2-core/src/test/java/br/usp/each/saeg/jaguar2/core/JaguarTest.java
+++ b/jaguar2-core/src/test/java/br/usp/each/saeg/jaguar2/core/JaguarTest.java
@@ -10,6 +10,7 @@
  */
 package br.usp.each.saeg.jaguar2.core;
 
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -19,6 +20,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import br.usp.each.saeg.jaguar2.api.ISpectrumVisitor;
 import br.usp.each.saeg.jaguar2.spi.CoverageController;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -76,7 +78,7 @@ public class JaguarTest {
         jaguar.testRunFinished();
 
         // Then
-        verify(controllerMock, times(1)).analyze(null);
+        verify(controllerMock, times(1)).analyze(any(ISpectrumVisitor.class));
     }
 
 }

--- a/jaguar2-examples/jaguar2-example-junit-jacoco/pom.xml
+++ b/jaguar2-examples/jaguar2-example-junit-jacoco/pom.xml
@@ -41,6 +41,9 @@
 							<value>br.usp.each.saeg.jaguar2.junit.JaguarJUnitRunListener</value>
 						</property>
 					</properties>
+					<systemPropertyVariables>
+						<jaguar2.classesDirs>../jaguar2-example-junit/target/classes</jaguar2.classesDirs>
+					</systemPropertyVariables>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/jaguar2-providers/jaguar2-jacoco-provider/pom.xml
+++ b/jaguar2-providers/jaguar2-jacoco-provider/pom.xml
@@ -32,6 +32,11 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>jaguar2-commons</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
 			<groupId>org.jacoco</groupId>
 			<artifactId>org.jacoco.agent</artifactId>
 			<version>${jacoco.version}</version>

--- a/jaguar2-providers/jaguar2-jacoco-provider/src/main/java/br/usp/each/saeg/jaguar2/jacoco/ClassSpectrum.java
+++ b/jaguar2-providers/jaguar2-jacoco-provider/src/main/java/br/usp/each/saeg/jaguar2/jacoco/ClassSpectrum.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2021, 2021 University of Sao Paulo and Contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Roberto Araujo - initial API and implementation and/or initial documentation
+ */
+package br.usp.each.saeg.jaguar2.jacoco;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.jacoco.core.analysis.IClassCoverage;
+import org.jacoco.core.analysis.IMethodCoverage;
+
+import br.usp.each.saeg.jaguar2.api.IClassSpectrum;
+
+public class ClassSpectrum extends CodeSpectrum implements IClassSpectrum {
+
+    private final Map<String, MethodSpectrum> methods = new LinkedHashMap<String, MethodSpectrum>();
+
+    private final IClassCoverage coverage;
+
+    public ClassSpectrum(final IClassCoverage coverage) {
+        this.coverage = coverage;
+    }
+
+    @Override
+    public String getName() {
+        return coverage.getName();
+    }
+
+    @Override
+    public Collection<MethodSpectrum> getMethods() {
+        return methods.values();
+    }
+
+    public void addMethod(final IMethodCoverage coverage) {
+        final MethodSpectrum spectrum = new MethodSpectrum(coverage);
+        methods.put(k(coverage.getName(), coverage.getDesc()), spectrum);
+    }
+
+    public MethodSpectrum getMethod(final IMethodCoverage coverage) {
+        return methods.get(k(coverage.getName(), coverage.getDesc()));
+    }
+
+    private String k(final String name, final String desc) {
+        final StringBuilder builder = new StringBuilder(name.length() + desc.length());
+        builder.append(name);
+        builder.append(desc);
+        return builder.toString();
+    }
+
+}

--- a/jaguar2-providers/jaguar2-jacoco-provider/src/main/java/br/usp/each/saeg/jaguar2/jacoco/CodeSpectrum.java
+++ b/jaguar2-providers/jaguar2-jacoco-provider/src/main/java/br/usp/each/saeg/jaguar2/jacoco/CodeSpectrum.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2021, 2021 University of Sao Paulo and Contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Roberto Araujo - initial API and implementation and/or initial documentation
+ */
+package br.usp.each.saeg.jaguar2.jacoco;
+
+import org.jacoco.core.analysis.ICounter;
+import org.jacoco.core.analysis.ILine;
+import org.jacoco.core.analysis.ISourceNode;
+
+import br.usp.each.saeg.jaguar2.api.ICodeSpectrum;
+
+public class CodeSpectrum implements ICodeSpectrum {
+
+    private LineSpectrum[] lines;
+
+    private int offset;
+
+    public CodeSpectrum() {
+        offset = UNKNOWN_LINE;
+    }
+
+    @Override
+    public int getFirstLine() {
+        return offset;
+    }
+
+    @Override
+    public int getLastLine() {
+        return lines == null ? UNKNOWN_LINE : offset + lines.length - 1;
+    }
+
+    @Override
+    public LineSpectrum getLine(final int nr) {
+        if (lines == null || nr < getFirstLine() || nr > getLastLine()) {
+            return LineSpectrum.EMPTY;
+        }
+        final LineSpectrum line = lines[nr - offset];
+        return line == null ? LineSpectrum.EMPTY : line;
+    }
+
+    private void ensureCapacity(final int first, final int last) {
+        if (first == UNKNOWN_LINE || last == UNKNOWN_LINE) {
+            return;
+        }
+        if (lines == null) {
+            offset = first;
+            lines = new LineSpectrum[last - first + 1];
+        } else {
+            final int newFirst = Math.min(getFirstLine(), first);
+            final int newLast = Math.max(getLastLine(), last);
+            final int newLength = newLast - newFirst + 1;
+            if (newLength > lines.length) {
+                final LineSpectrum[] newLines = new LineSpectrum[newLength];
+                System.arraycopy(lines, 0, newLines, offset - newFirst, lines.length);
+                offset = newFirst;
+                lines = newLines;
+            }
+        }
+    }
+
+    public void increment(final ISourceNode coverage, final boolean testFailed) {
+        final int firstLine = coverage.getFirstLine();
+        if (firstLine != UNKNOWN_LINE) {
+            final int lastLine = coverage.getLastLine();
+            for (int i = firstLine; i <= lastLine; i++) {
+                final ILine line = coverage.getLine(i);
+                switch (line.getInstructionCounter().getStatus()) {
+                case ICounter.FULLY_COVERED:
+                case ICounter.PARTLY_COVERED:
+                    ensureCapacity(i, i);
+                    lines[i - offset] = getLine(i).increment(testFailed);
+                }
+            }
+        }
+    }
+
+}

--- a/jaguar2-providers/jaguar2-jacoco-provider/src/main/java/br/usp/each/saeg/jaguar2/jacoco/CodeSpectrum.java
+++ b/jaguar2-providers/jaguar2-jacoco-provider/src/main/java/br/usp/each/saeg/jaguar2/jacoco/CodeSpectrum.java
@@ -69,12 +69,12 @@ public class CodeSpectrum implements ICodeSpectrum {
         final int firstLine = coverage.getFirstLine();
         if (firstLine != UNKNOWN_LINE) {
             final int lastLine = coverage.getLastLine();
+            ensureCapacity(firstLine, lastLine);
             for (int i = firstLine; i <= lastLine; i++) {
                 final ILine line = coverage.getLine(i);
                 switch (line.getInstructionCounter().getStatus()) {
                 case ICounter.FULLY_COVERED:
                 case ICounter.PARTLY_COVERED:
-                    ensureCapacity(i, i);
                     lines[i - offset] = getLine(i).increment(testFailed);
                 }
             }

--- a/jaguar2-providers/jaguar2-jacoco-provider/src/main/java/br/usp/each/saeg/jaguar2/jacoco/LineSpectrum.java
+++ b/jaguar2-providers/jaguar2-jacoco-provider/src/main/java/br/usp/each/saeg/jaguar2/jacoco/LineSpectrum.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2021, 2021 University of Sao Paulo and Contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Roberto Araujo - initial API and implementation and/or initial documentation
+ */
+package br.usp.each.saeg.jaguar2.jacoco;
+
+import br.usp.each.saeg.jaguar2.api.ILineSpectrum;
+
+public class LineSpectrum implements ILineSpectrum {
+
+    public static final LineSpectrum EMPTY = new LineSpectrum(0, 0);
+
+    private final int cef;
+
+    private final int cep;
+
+    private LineSpectrum(final int cef, final int cep) {
+        this.cef = cef;
+        this.cep = cep;
+    }
+
+    @Override
+    public int getCef() {
+        return cef;
+    }
+
+    @Override
+    public int getCep() {
+        return cep;
+    }
+
+    public LineSpectrum increment(final boolean testFailed) {
+        if (testFailed) {
+            return new LineSpectrum(cef + 1, cep);
+        } else {
+            return new LineSpectrum(cef, cep + 1);
+        }
+    }
+
+}

--- a/jaguar2-providers/jaguar2-jacoco-provider/src/main/java/br/usp/each/saeg/jaguar2/jacoco/MethodSpectrum.java
+++ b/jaguar2-providers/jaguar2-jacoco-provider/src/main/java/br/usp/each/saeg/jaguar2/jacoco/MethodSpectrum.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2021, 2021 University of Sao Paulo and Contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Roberto Araujo - initial API and implementation and/or initial documentation
+ */
+package br.usp.each.saeg.jaguar2.jacoco;
+
+import org.jacoco.core.analysis.IMethodCoverage;
+
+import br.usp.each.saeg.jaguar2.api.IMethodSpectrum;
+
+public class MethodSpectrum extends CodeSpectrum implements IMethodSpectrum {
+
+    private final IMethodCoverage coverage;
+
+    public MethodSpectrum(final IMethodCoverage coverage) {
+        this.coverage = coverage;
+    }
+
+    @Override
+    public String getName() {
+        return coverage.getName();
+    }
+
+    @Override
+    public String getDesc() {
+        return coverage.getDesc();
+    }
+
+}

--- a/jaguar2-providers/jaguar2-jacoco-provider/src/main/java/br/usp/each/saeg/jaguar2/jacoco/SpectrumBuilder.java
+++ b/jaguar2-providers/jaguar2-jacoco-provider/src/main/java/br/usp/each/saeg/jaguar2/jacoco/SpectrumBuilder.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2021, 2021 University of Sao Paulo and Contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Roberto Araujo - initial API and implementation and/or initial documentation
+ */
+package br.usp.each.saeg.jaguar2.jacoco;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jacoco.core.analysis.IClassCoverage;
+import org.jacoco.core.analysis.ICoverageVisitor;
+import org.jacoco.core.analysis.IMethodCoverage;
+
+import br.usp.each.saeg.jaguar2.api.ISpectrumVisitor;
+
+public class SpectrumBuilder implements ICoverageVisitor {
+
+    private final Map<String, ClassSpectrum> classes = new HashMap<String, ClassSpectrum>();
+
+    public final UpdateSpectrum updateTestFailed = new UpdateSpectrum(true);
+
+    public final UpdateSpectrum updateTestPassed = new UpdateSpectrum(false);
+
+    @Override
+    public void visitCoverage(final IClassCoverage classCoverage) {
+        final ClassSpectrum cs = new ClassSpectrum(classCoverage);
+        for (final IMethodCoverage methodCoverage : classCoverage.getMethods()) {
+            cs.addMethod(methodCoverage);
+        }
+        classes.put(cs.getName(), cs);
+    }
+
+    private class UpdateSpectrum implements ICoverageVisitor {
+
+        private final boolean testFailed;
+
+        public UpdateSpectrum(final boolean testFailed) {
+            this.testFailed = testFailed;
+        }
+
+        @Override
+        public void visitCoverage(final IClassCoverage classCoverage) {
+            final ClassSpectrum cs = classes.get(classCoverage.getName());
+            cs.increment(classCoverage, testFailed);
+            for (final IMethodCoverage methodCoverage : classCoverage.getMethods()) {
+                cs.getMethod(methodCoverage).increment(methodCoverage, testFailed);
+            }
+        }
+
+    }
+
+    public void accept(final ISpectrumVisitor spectrumVisitor) {
+        for (final ClassSpectrum cs : classes.values()) {
+            spectrumVisitor.visitSpectrum(cs);
+        }
+    }
+
+}


### PR DESCRIPTION
This commit is the initial implementation for Jaguar2 JaCoCo Provider
analysis and includes custom Spectrum interfaces implementations for use
with JaCoCo and an initial analysis implementation.

We also extracted an abstract `CoverageController` class called
`ClassFilesController` to Jaguar2 Commons module, an abstract controller
used for analysis that requires the class files (probably required for
Jaguar2 BA-DUA Provider).