### PR TITLE
Create Jaguar2 Validations module

### DIFF
--- a/jaguar2-validations/.gitignore
+++ b/jaguar2-validations/.gitignore
@@ -1,0 +1,12 @@
+*.class
+/target
+
+# Package Files #
+*.jar
+*.war
+*.ear
+
+# eclipse
+/.classpath
+/.project
+/.settings

--- a/jaguar2-validations/pom.xml
+++ b/jaguar2-validations/pom.xml
@@ -1,0 +1,13 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>br.usp.each.saeg</groupId>
+		<artifactId>jaguar2-parent</artifactId>
+		<version>0.0.1-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>jaguar2-validations</artifactId>
+	<packaging>pom</packaging>
+
+</project>

--- a/jaguar2-validations/pom.xml
+++ b/jaguar2-validations/pom.xml
@@ -27,6 +27,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-verifier-plugin</artifactId>
+				<version>1.1</version>
 				<executions>
 					<execution>
 						<goals>

--- a/jaguar2-validations/pom.xml
+++ b/jaguar2-validations/pom.xml
@@ -36,6 +36,45 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<!-- Using this version to support requireFileChecksum with Java 6 -->
+				<version>3.0.0-M1</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<phase>verify</phase>
+						<configuration>
+							<rules>
+								<requireFileChecksum>
+									<file>../jaguar2-examples/jaguar2-example-junit-ba-dua/target/jaguar2.csv</file>
+									<checksum>0</checksum>
+									<type>md5</type>
+								</requireFileChecksum>
+								<requireFileChecksum>
+									<file>../jaguar2-examples/jaguar2-example-junit-jacoco/target/jaguar2.csv</file>
+									<checksum>0</checksum>
+									<type>md5</type>
+								</requireFileChecksum>
+								<requireFileChecksum>
+									<file>../jaguar2-examples/jaguar2-example-junit-ba-dua/target/jaguar2.xml</file>
+									<checksum>0</checksum>
+									<type>md5</type>
+								</requireFileChecksum>
+								<requireFileChecksum>
+									<file>../jaguar2-examples/jaguar2-example-junit-jacoco/target/jaguar2.xml</file>
+									<checksum>0</checksum>
+									<type>md5</type>
+								</requireFileChecksum>
+							</rules>
+							<fail>true</fail>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/jaguar2-validations/pom.xml
+++ b/jaguar2-validations/pom.xml
@@ -22,4 +22,20 @@
 	<artifactId>jaguar2-validations</artifactId>
 	<packaging>pom</packaging>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-verifier-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>verify</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
 </project>

--- a/jaguar2-validations/pom.xml
+++ b/jaguar2-validations/pom.xml
@@ -1,3 +1,15 @@
+<!--
+
+    Copyright (c) 2021, 2021 University of Sao Paulo and Contributors.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Roberto Araujo - initial API and implementation and/or initial documentation
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 

--- a/jaguar2-validations/pom.xml
+++ b/jaguar2-validations/pom.xml
@@ -51,22 +51,22 @@
 							<rules>
 								<requireFileChecksum>
 									<file>../jaguar2-examples/jaguar2-example-junit-ba-dua/target/jaguar2.csv</file>
-									<checksum>0</checksum>
+									<checksum>d41d8cd98f00b204e9800998ecf8427e</checksum>
 									<type>md5</type>
 								</requireFileChecksum>
 								<requireFileChecksum>
 									<file>../jaguar2-examples/jaguar2-example-junit-jacoco/target/jaguar2.csv</file>
-									<checksum>0</checksum>
+									<checksum>b0b094bc318faf9d5400534c7f28493d</checksum>
 									<type>md5</type>
 								</requireFileChecksum>
 								<requireFileChecksum>
 									<file>../jaguar2-examples/jaguar2-example-junit-ba-dua/target/jaguar2.xml</file>
-									<checksum>0</checksum>
+									<checksum>66973079dc7fdc0eedbbcbed1bf0bde0</checksum>
 									<type>md5</type>
 								</requireFileChecksum>
 								<requireFileChecksum>
 									<file>../jaguar2-examples/jaguar2-example-junit-jacoco/target/jaguar2.xml</file>
-									<checksum>0</checksum>
+									<checksum>30dd5b84869a04e8505d05c4de55e37f</checksum>
 									<type>md5</type>
 								</requireFileChecksum>
 							</rules>

--- a/jaguar2-validations/src/test/verifier/verifications.xml
+++ b/jaguar2-validations/src/test/verifier/verifications.xml
@@ -1,2 +1,14 @@
+<!--
+
+    Copyright (c) 2021, 2021 University of Sao Paulo and Contributors.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Roberto Araujo - initial API and implementation and/or initial documentation
+
+-->
 <verifications xmlns="http://maven.apache.org/verifications/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/verifications/1.0.0 http://maven.apache.org/xsd/verifications-1.0.0.xsd">
 </verifications>

--- a/jaguar2-validations/src/test/verifier/verifications.xml
+++ b/jaguar2-validations/src/test/verifier/verifications.xml
@@ -12,12 +12,46 @@
 -->
 <verifications xmlns="http://maven.apache.org/verifications/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/verifications/1.0.0 http://maven.apache.org/xsd/verifications-1.0.0.xsd">
 	<files>
+		<!-- Verify test jaguar2-example-junit -->
 		<file>
-			<location>../jaguar2-examples/jaguar2-example-junit/target/surefire-reports/not-exists.txt</location>
+			<location>../jaguar2-examples/jaguar2-example-junit/target/surefire-reports/br.usp.each.saeg.jaguar2.MaxTest.txt</location>
+			<contains>Tests run: 5, Failures: 1, Errors: 1, Skipped: 0</contains>
 		</file>
 		<file>
 			<location>../jaguar2-examples/jaguar2-example-junit/target/surefire-reports/br.usp.each.saeg.jaguar2.MaxTest.txt</location>
-			<contains>Bad Expression</contains>
+			<contains>test4\(br.usp.each.saeg.jaguar2.MaxTest\)</contains>
+		</file>
+		<file>
+			<location>../jaguar2-examples/jaguar2-example-junit/target/surefire-reports/br.usp.each.saeg.jaguar2.MaxTest.txt</location>
+			<contains>test5\(br.usp.each.saeg.jaguar2.MaxTest\)</contains>
+		</file>
+
+		<!-- Verify test jaguar2-example-junit-ba-dua -->
+		<file>
+			<location>../jaguar2-examples/jaguar2-example-junit-ba-dua/target/surefire-reports/br.usp.each.saeg.jaguar2.MaxTest.txt</location>
+			<contains>Tests run: 5, Failures: 1, Errors: 1, Skipped: 0</contains>
+		</file>
+		<file>
+			<location>../jaguar2-examples/jaguar2-example-junit-ba-dua/target/surefire-reports/br.usp.each.saeg.jaguar2.MaxTest.txt</location>
+			<contains>test4\(br.usp.each.saeg.jaguar2.MaxTest\)</contains>
+		</file>
+		<file>
+			<location>../jaguar2-examples/jaguar2-example-junit-ba-dua/target/surefire-reports/br.usp.each.saeg.jaguar2.MaxTest.txt</location>
+			<contains>test5\(br.usp.each.saeg.jaguar2.MaxTest\)</contains>
+		</file>
+
+		<!-- Verify test jaguar2-example-junit-jacoco -->
+		<file>
+			<location>../jaguar2-examples/jaguar2-example-junit-jacoco/target/surefire-reports/br.usp.each.saeg.jaguar2.MaxTest.txt</location>
+			<contains>Tests run: 5, Failures: 1, Errors: 1, Skipped: 0</contains>
+		</file>
+		<file>
+			<location>../jaguar2-examples/jaguar2-example-junit-jacoco/target/surefire-reports/br.usp.each.saeg.jaguar2.MaxTest.txt</location>
+			<contains>test4\(br.usp.each.saeg.jaguar2.MaxTest\)</contains>
+		</file>
+		<file>
+			<location>../jaguar2-examples/jaguar2-example-junit-jacoco/target/surefire-reports/br.usp.each.saeg.jaguar2.MaxTest.txt</location>
+			<contains>test5\(br.usp.each.saeg.jaguar2.MaxTest\)</contains>
 		</file>
 	</files>
 </verifications>

--- a/jaguar2-validations/src/test/verifier/verifications.xml
+++ b/jaguar2-validations/src/test/verifier/verifications.xml
@@ -1,0 +1,2 @@
+<verifications xmlns="http://maven.apache.org/verifications/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/verifications/1.0.0 http://maven.apache.org/xsd/verifications-1.0.0.xsd">
+</verifications>

--- a/jaguar2-validations/src/test/verifier/verifications.xml
+++ b/jaguar2-validations/src/test/verifier/verifications.xml
@@ -11,4 +11,13 @@
 
 -->
 <verifications xmlns="http://maven.apache.org/verifications/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/verifications/1.0.0 http://maven.apache.org/xsd/verifications-1.0.0.xsd">
+	<files>
+		<file>
+			<location>../jaguar2-examples/jaguar2-example-junit/target/surefire-reports/not-exists.txt</location>
+		</file>
+		<file>
+			<location>../jaguar2-examples/jaguar2-example-junit/target/surefire-reports/br.usp.each.saeg.jaguar2.MaxTest.txt</location>
+			<contains>Bad Expression</contains>
+		</file>
+	</files>
 </verifications>

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,7 @@
 		<module>jaguar2-providers</module>
 		<module>jaguar2-exporters</module>
 		<module>jaguar2-examples</module>
+		<module>jaguar2-validations</module>
 	</modules>
 
 	<build>


### PR DESCRIPTION
    This pull request create a new module Jaguar2 Validations

    This new module performs simple validations on resources generated
    during the project build.

    Using Apache Maven Verifier to check file content against a regular
    expression and Maven Enforcer Plugin to enforces that specified files
    has a certain checksum

    Validates that examples tests output contains expected values. The
    examples are expecting some test failures, but since Maven Surefire
    Plugin is ignoring these failures, we can hide  unexpected behaviour

    Also validates that examples Jaguar2 reports matchs expected checksum.