### PR TITLE
Symblink src/main examples

### DIFF
--- a/jaguar2-examples/jaguar2-example-junit-ba-dua/pom.xml
+++ b/jaguar2-examples/jaguar2-example-junit-ba-dua/pom.xml
@@ -87,11 +87,6 @@
 			<groupId>${project.groupId}</groupId>
 			<artifactId>jaguar2-example-junit</artifactId>
 			<version>${project.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>${project.groupId}</groupId>
-			<artifactId>jaguar2-example-junit</artifactId>
-			<version>${project.version}</version>
 			<classifier>tests</classifier>
 			<scope>test</scope>
 		</dependency>

--- a/jaguar2-examples/jaguar2-example-junit-ba-dua/src/main
+++ b/jaguar2-examples/jaguar2-example-junit-ba-dua/src/main
@@ -1,0 +1,1 @@
+../../jaguar2-example-junit/src/main

--- a/jaguar2-examples/jaguar2-example-junit-jacoco/pom.xml
+++ b/jaguar2-examples/jaguar2-example-junit-jacoco/pom.xml
@@ -43,7 +43,7 @@
 						</property>
 					</properties>
 					<systemPropertyVariables>
-						<jaguar2.classesDirs>../jaguar2-example-junit/target/classes</jaguar2.classesDirs>
+						<jaguar2.classesDirs>${project.build.outputDirectory}</jaguar2.classesDirs>
 					</systemPropertyVariables>
 				</configuration>
 			</plugin>

--- a/jaguar2-examples/jaguar2-example-junit-jacoco/pom.xml
+++ b/jaguar2-examples/jaguar2-example-junit-jacoco/pom.xml
@@ -55,11 +55,6 @@
 			<groupId>${project.groupId}</groupId>
 			<artifactId>jaguar2-example-junit</artifactId>
 			<version>${project.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>${project.groupId}</groupId>
-			<artifactId>jaguar2-example-junit</artifactId>
-			<version>${project.version}</version>
 			<classifier>tests</classifier>
 			<scope>test</scope>
 		</dependency>

--- a/jaguar2-examples/jaguar2-example-junit-jacoco/src/main
+++ b/jaguar2-examples/jaguar2-example-junit-jacoco/src/main
@@ -1,0 +1,1 @@
+../../jaguar2-example-junit/src/main


### PR DESCRIPTION
This is to avoid include Jaguar2 JUnit Example module "src/main" as a dependency from other example modules. I hope it will make Maven POM examples more realistic.