### PR TITLE
Jaguar2 Example JUnit JaCoCo do not inherit Jaguar2 Parent POM

### DIFF
--- a/jaguar2-examples/jaguar2-example-junit-jacoco/pom.xml
+++ b/jaguar2-examples/jaguar2-example-junit-jacoco/pom.xml
@@ -13,16 +13,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<parent>
-		<groupId>br.usp.each.saeg</groupId>
-		<artifactId>jaguar2-examples</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-	</parent>
-
+	<groupId>br.usp.each.saeg</groupId>
 	<artifactId>jaguar2-example-junit-jacoco</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
 
 	<properties>
-		<license.header.fileLocation>../../LICENSE-TEMPLATE.txt</license.header.fileLocation>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<maven.compiler.source>1.6</maven.compiler.source>
+		<maven.compiler.target>1.6</maven.compiler.target>
 	</properties>
 
 	<build>
@@ -30,6 +28,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.12.4</version>
 				<configuration>
 					<testFailureIgnore>true</testFailureIgnore>
 					<properties>
@@ -47,6 +46,12 @@
 	</build>
 
 	<dependencies>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.13.2</version>
+			<scope>test</scope>
+		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>jaguar2-junit</artifactId>
@@ -72,5 +77,28 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+
+	<profiles>
+		<profile>
+			<id>jdk12</id>
+			<activation>
+				<jdk>[12,20)</jdk>
+			</activation>
+			<properties>
+				<maven.compiler.source>1.7</maven.compiler.source>
+				<maven.compiler.target>1.7</maven.compiler.target>
+			</properties>
+		</profile>
+		<profile>
+			<id>jdk20</id>
+			<activation>
+				<jdk>[20,)</jdk>
+			</activation>
+			<properties>
+				<maven.compiler.source>1.8</maven.compiler.source>
+				<maven.compiler.target>1.8</maven.compiler.target>
+			</properties>
+		</profile>
+	</profiles>
 
 </project>

--- a/jaguar2-examples/jaguar2-example-junit-jacoco/pom.xml
+++ b/jaguar2-examples/jaguar2-example-junit-jacoco/pom.xml
@@ -26,6 +26,19 @@
 	<build>
 		<plugins>
 			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.7</version>
+				<executions>
+					<execution>
+						<id>prepare-agent</id>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.12.4</version>


### PR DESCRIPTION
This is basically the same of PR #42 and #43 but for Jaguar2 Example JUnit JaCoCo module and in a single shot.

Trust me, all these changes are required.