### PR TITLE
Inject `SpectrumExporter` to `Jaguar` via constructor

### DIFF
--- a/jaguar2-core/src/main/java/br/usp/each/saeg/jaguar2/core/Jaguar.java
+++ b/jaguar2-core/src/main/java/br/usp/each/saeg/jaguar2/core/Jaguar.java
@@ -10,13 +10,10 @@
  */
 package br.usp.each.saeg.jaguar2.core;
 
-import br.usp.each.saeg.jaguar2.CoverageControllerLoader;
-import br.usp.each.saeg.jaguar2.SpectrumExporterLoader;
 import br.usp.each.saeg.jaguar2.api.Heuristic;
 import br.usp.each.saeg.jaguar2.api.IClassSpectrum;
 import br.usp.each.saeg.jaguar2.api.ILineSpectrum;
 import br.usp.each.saeg.jaguar2.api.SpectrumEval;
-import br.usp.each.saeg.jaguar2.core.heuristic.Ochiai;
 import br.usp.each.saeg.jaguar2.spi.CoverageController;
 import br.usp.each.saeg.jaguar2.spi.SpectrumExporter;
 
@@ -24,21 +21,23 @@ public class Jaguar implements SpectrumEval {
 
     private final CoverageController controller;
 
+    private final SpectrumExporter exporter;
+
     private final Heuristic heuristic;
 
     private int failedTests;
 
     private int passedTests;
 
-    public Jaguar(final CoverageController controller, final Heuristic heuristic) {
+    public Jaguar(
+            final CoverageController controller,
+            final SpectrumExporter exporter,
+            final Heuristic heuristic) {
         this.controller = controller;
+        this.exporter = exporter;
         this.heuristic = heuristic;
         failedTests = 0;
         passedTests = 0;
-    }
-
-    public Jaguar() {
-        this(new CoverageControllerLoader().load(), new Ochiai());
     }
 
     /**
@@ -89,7 +88,6 @@ public class Jaguar implements SpectrumEval {
      * @throws Exception
      */
     public void testRunFinished() throws Exception {
-        final SpectrumExporter exporter = new SpectrumExporterLoader().load();
         exporter.init();
         if (controller != null) {
             for (final IClassSpectrum spectrum : controller.analyze()) {

--- a/jaguar2-core/src/test/java/br/usp/each/saeg/jaguar2/core/JaguarEvalTest.java
+++ b/jaguar2-core/src/test/java/br/usp/each/saeg/jaguar2/core/JaguarEvalTest.java
@@ -24,12 +24,16 @@ import org.mockito.runners.MockitoJUnitRunner;
 import br.usp.each.saeg.jaguar2.api.Heuristic;
 import br.usp.each.saeg.jaguar2.api.ILineSpectrum;
 import br.usp.each.saeg.jaguar2.spi.CoverageController;
+import br.usp.each.saeg.jaguar2.spi.SpectrumExporter;
 
 @RunWith(MockitoJUnitRunner.class)
 public class JaguarEvalTest {
 
     @Mock
     private CoverageController controllerMock;
+
+    @Mock
+    private SpectrumExporter exporterMock;
 
     @Mock
     private Heuristic heuristicMock;
@@ -40,7 +44,7 @@ public class JaguarEvalTest {
 
     @Before
     public void setUp() {
-        jaguar = new Jaguar(controllerMock, heuristicMock);
+        jaguar = new Jaguar(controllerMock, exporterMock, heuristicMock);
         expectedValue = Math.random();
     }
 

--- a/jaguar2-junit4/src/main/java/br/usp/each/saeg/jaguar2/junit/JaguarJUnitRunListener.java
+++ b/jaguar2-junit4/src/main/java/br/usp/each/saeg/jaguar2/junit/JaguarJUnitRunListener.java
@@ -15,7 +15,10 @@ import org.junit.runner.Result;
 import org.junit.runner.notification.Failure;
 import org.junit.runner.notification.RunListener;
 
+import br.usp.each.saeg.jaguar2.CoverageControllerLoader;
+import br.usp.each.saeg.jaguar2.SpectrumExporterLoader;
 import br.usp.each.saeg.jaguar2.core.Jaguar;
+import br.usp.each.saeg.jaguar2.core.heuristic.Ochiai;
 
 public class JaguarJUnitRunListener extends RunListener {
 
@@ -30,7 +33,10 @@ public class JaguarJUnitRunListener extends RunListener {
     }
 
     public JaguarJUnitRunListener() {
-        this(new Jaguar());
+        this(new Jaguar(
+                new CoverageControllerLoader().load(),
+                new SpectrumExporterLoader().load(),
+                new Ochiai()));
     }
 
     @Override


### PR DESCRIPTION
This will allow better decoupling and testability. Also added some tests to ensure class spectrum are exported correctly.

Note that we also removed the default no-args constructor from `Jaguar` class. So clients from this class should inject all dependencies via the other constructor.