### PR TITLE
Create interface `ISourceFileSpectrum`

### DIFF
--- a/jaguar2-api/src/main/java/br/usp/each/saeg/jaguar2/api/IClassSpectrum.java
+++ b/jaguar2-api/src/main/java/br/usp/each/saeg/jaguar2/api/IClassSpectrum.java
@@ -35,6 +35,13 @@ public interface IClassSpectrum extends ICodeSpectrum {
     String getPackageName();
 
     /**
+     * Returns the optional name of the corresponding source file.
+     *
+     * @return name of the corresponding source file.
+     */
+    String getSourceFileName();
+
+    /**
      * Returns the spectrum data of methods included in this class.
      *
      * @return a {@link Collection} of {@link IMethodSpectrum}.

--- a/jaguar2-api/src/main/java/br/usp/each/saeg/jaguar2/api/IPackageSpectrum.java
+++ b/jaguar2-api/src/main/java/br/usp/each/saeg/jaguar2/api/IPackageSpectrum.java
@@ -12,6 +12,12 @@ package br.usp.each.saeg.jaguar2.api;
 
 import java.util.Collection;
 
+/**
+ * Spectrum data of a single package.
+ *
+ * @see IClassSpectrum
+ * @see ISourceFileSpectrum
+ */
 public interface IPackageSpectrum {
 
     /**
@@ -27,5 +33,12 @@ public interface IPackageSpectrum {
      * @return a {@link Collection} of {@link IClassSpectrum}.
      */
     Collection<? extends IClassSpectrum> getClasses();
+
+    /**
+     * Returns the spectrum data of source files included in this package.
+     *
+     * @return a {@link Collection} of {@link ISourceFileSpectrum}.
+     */
+    Collection<? extends ISourceFileSpectrum> getSourceFiles();
 
 }

--- a/jaguar2-api/src/main/java/br/usp/each/saeg/jaguar2/api/ISourceFileSpectrum.java
+++ b/jaguar2-api/src/main/java/br/usp/each/saeg/jaguar2/api/ISourceFileSpectrum.java
@@ -10,20 +10,20 @@
  */
 package br.usp.each.saeg.jaguar2.api;
 
-import java.util.Collection;
-
-/**
- * Spectrum data of a group of packages.
- *
- * @see IPackageSpectrum
- */
-public interface IBundleSpectrum {
+public interface ISourceFileSpectrum extends ICodeSpectrum {
 
     /**
-     * Returns the spectrum data of packages included in this bundle.
+     * Returns name of the corresponding source file.
      *
-     * @return a {@link Collection} of {@link IPackageSpectrum}.
+     * @return name of the corresponding source file.
      */
-    Collection<? extends IPackageSpectrum> getPackages();
+    String getName();
+
+    /**
+     * Returns the VM name of the package the source file belongs to.
+     *
+     * @return VM name of the package.
+     */
+    String getPackageName();
 
 }

--- a/jaguar2-providers/jaguar2-jacoco-provider/src/main/java/br/usp/each/saeg/jaguar2/jacoco/ClassSpectrum.java
+++ b/jaguar2-providers/jaguar2-jacoco-provider/src/main/java/br/usp/each/saeg/jaguar2/jacoco/ClassSpectrum.java
@@ -40,6 +40,11 @@ public class ClassSpectrum extends CodeSpectrum implements IClassSpectrum {
     }
 
     @Override
+    public String getSourceFileName() {
+        return coverage.getSourceFileName();
+    }
+
+    @Override
     public Collection<MethodSpectrum> getMethods() {
         return methods.values();
     }

--- a/jaguar2-providers/jaguar2-jacoco-provider/src/main/java/br/usp/each/saeg/jaguar2/jacoco/JaCoCoController.java
+++ b/jaguar2-providers/jaguar2-jacoco-provider/src/main/java/br/usp/each/saeg/jaguar2/jacoco/JaCoCoController.java
@@ -128,7 +128,8 @@ public class JaCoCoController extends ClassFilesController implements CoverageCo
             final Collection<File> files = classFilesOfStore(executionDataStore);
             analyze(executionDataStore, spectrumBuilder.updateTestPassed, files);
         }
-        return new BundleSpectrum(spectrumBuilder.getClasses());
+        return new BundleSpectrum(
+                spectrumBuilder.getClasses(), spectrumBuilder.getSourceFiles());
     }
 
     @Override

--- a/jaguar2-providers/jaguar2-jacoco-provider/src/main/java/br/usp/each/saeg/jaguar2/jacoco/PackageSpectrum.java
+++ b/jaguar2-providers/jaguar2-jacoco-provider/src/main/java/br/usp/each/saeg/jaguar2/jacoco/PackageSpectrum.java
@@ -20,9 +20,15 @@ public class PackageSpectrum implements IPackageSpectrum {
 
     private final Collection<ClassSpectrum> classes;
 
-    public PackageSpectrum(final String name, final Collection<ClassSpectrum> classes) {
+    private final Collection<SourceFileSpectrum> sourceFiles;
+
+    public PackageSpectrum(final String name,
+            final Collection<ClassSpectrum> classes,
+            final Collection<SourceFileSpectrum> sourceFiles) {
+
         this.name = name;
         this.classes = classes;
+        this.sourceFiles = sourceFiles;
     }
 
     @Override
@@ -33,6 +39,11 @@ public class PackageSpectrum implements IPackageSpectrum {
     @Override
     public Collection<ClassSpectrum> getClasses() {
         return classes;
+    }
+
+    @Override
+    public Collection<SourceFileSpectrum> getSourceFiles() {
+        return sourceFiles;
     }
 
 }

--- a/jaguar2-providers/jaguar2-jacoco-provider/src/main/java/br/usp/each/saeg/jaguar2/jacoco/SourceFileSpectrum.java
+++ b/jaguar2-providers/jaguar2-jacoco-provider/src/main/java/br/usp/each/saeg/jaguar2/jacoco/SourceFileSpectrum.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2021, 2021 University of Sao Paulo and Contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Roberto Araujo - initial API and implementation and/or initial documentation
+ */
+package br.usp.each.saeg.jaguar2.jacoco;
+
+import br.usp.each.saeg.jaguar2.api.ISourceFileSpectrum;
+
+public class SourceFileSpectrum extends CodeSpectrum implements ISourceFileSpectrum {
+
+    private final String name;
+
+    private final String packageName;
+
+    public SourceFileSpectrum(final String name, final String packageName) {
+        this.name = name;
+        this.packageName = packageName;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getPackageName() {
+        return packageName;
+    }
+
+}


### PR DESCRIPTION
This commit also create the implementations of this interfaces for Jaguar2 JaCoCo Provider. The `BundleSpectrum` is responsible for group all `SourceFileSpectrum` within a respective `PackageSpectrum`. Note that now the interface `IPackageSpectrum` provides a new method to access the list of `ISourceFileSpectrum`within the respective package along with the other method that provides access to the list of `IClassSpectrum` within the same package.

The `SpectrumBuilder` from Jaguar2 JaCoCo Provider is the one that instantiate implementations of this interface based on the source file name from the respective `ClassSpectrum`. That's why we added a new method on `IClassSpectrum` to get the respective file source name. The builder also increments the tests counters.

We also added JavaDoc for `IBundleSpectrum` and `IPackageSpectrum` that was forgotten in the previous commit PR #55 (32cc818)