### PR TITLE
Optimize XML output

### DIFF
--- a/jaguar2-exporters/jaguar2-xml-exporter/src/main/java/br/usp/each/saeg/jaguar2/xml/XmlExporter.java
+++ b/jaguar2-exporters/jaguar2-xml-exporter/src/main/java/br/usp/each/saeg/jaguar2/xml/XmlExporter.java
@@ -74,17 +74,13 @@ public class XmlExporter implements SpectrumExporter {
             final double susp = eval.eval(line);
             if (susp > 0.0d) {
                 final int cef = eval.getCef(line);
-                final int cnf = eval.getCnf(line);
                 final int cep = eval.getCep(line);
-                final int cnp = eval.getCnp(line);
 
                 writer.writeStartElement("line");
                 writer.writeAttribute("nr", String.valueOf(nr));
                 writer.writeAttribute("cef", String.valueOf(cef));
-                writer.writeAttribute("cnf", String.valueOf(cnf));
                 writer.writeAttribute("cep", String.valueOf(cep));
-                writer.writeAttribute("cnp", String.valueOf(cnp));
-                writer.writeAttribute("susp", String.valueOf(susp));
+                writer.writeAttribute("susp", String.format("%f", susp));
                 writer.writeEndElement();
             }
         }

--- a/jaguar2-validations/pom.xml
+++ b/jaguar2-validations/pom.xml
@@ -70,7 +70,7 @@
 								</requireFileChecksum>
 								<requireFileChecksum>
 									<file>../jaguar2-examples/jaguar2-example-junit4-jacoco/target/jaguar2.xml</file>
-									<checksum>ce63d64406513bff4e3bde9dace1bdf2</checksum>
+									<checksum>195983d8b7396375439d2aec507045b3</checksum>
 									<type>md5</type>
 								</requireFileChecksum>
 							</rules>


### PR DESCRIPTION
* Remove CNF and CNP
* Suspiciousness format using float (less decimal places)

CNF and CNP can be easily derived by number of failed/passed tests:

```
CNF = tests.fail - line.cef
CNP = tests.pass - line.cep
```