### PR TITLE
Allow dump coverage

### DIFF
--- a/jaguar2-api/src/main/java/br/usp/each/saeg/jaguar2/spi/CoverageController.java
+++ b/jaguar2-api/src/main/java/br/usp/each/saeg/jaguar2/spi/CoverageController.java
@@ -10,6 +10,8 @@
  */
 package br.usp.each.saeg.jaguar2.spi;
 
+import java.io.IOException;
+
 import br.usp.each.saeg.jaguar2.api.IBundleSpectrum;
 
 /**
@@ -26,6 +28,16 @@ public interface CoverageController {
      * Reset runtime code coverage data.
      */
     void reset();
+
+    /**
+     * Dump runtime code coverage data.
+     *
+     * @param reset a flag indicating that code coverage data should
+     *              also be reset.
+     *
+     * @throws IOException in case of exceptions during dump.
+     */
+    void dump(boolean reset) throws IOException;
 
     /**
      * Save runtime code coverage data for further analysis. The data is

--- a/jaguar2-api/src/test/java/br/usp/each/saeg/jaguar2/DummyCoverageController.java
+++ b/jaguar2-api/src/test/java/br/usp/each/saeg/jaguar2/DummyCoverageController.java
@@ -24,6 +24,10 @@ public class DummyCoverageController implements CoverageController {
     }
 
     @Override
+    public void dump(final boolean reset) {
+    }
+
+    @Override
     public void save(final boolean testFailed) {
     }
 

--- a/jaguar2-core/src/main/java/br/usp/each/saeg/jaguar2/core/Jaguar.java
+++ b/jaguar2-core/src/main/java/br/usp/each/saeg/jaguar2/core/Jaguar.java
@@ -10,6 +10,8 @@
  */
 package br.usp.each.saeg.jaguar2.core;
 
+import java.io.IOException;
+
 import br.usp.each.saeg.jaguar2.api.Heuristic;
 import br.usp.each.saeg.jaguar2.api.IBundleSpectrum;
 import br.usp.each.saeg.jaguar2.api.ILineSpectrum;
@@ -55,9 +57,32 @@ public class Jaguar implements SpectrumEval {
 
     private final Heuristic heuristic;
 
+    private final boolean noDump;
+
     private int failedTests;
 
     private int passedTests;
+
+    /**
+     * Instantiate a {@link Jaguar}.
+     *
+     * @param controller a {@link CoverageController}.
+     * @param exporter   a {@link SpectrumExporter}.
+     * @param heuristic  a {@link Heuristic}.
+     * @param noDump     enable not dump and only reset the coverage.
+     */
+    public Jaguar(
+            final CoverageController controller,
+            final SpectrumExporter exporter,
+            final Heuristic heuristic,
+            final boolean noDump) {
+        this.controller = controller;
+        this.exporter = exporter;
+        this.heuristic = heuristic;
+        this.noDump = noDump;
+        failedTests = 0;
+        passedTests = 0;
+    }
 
     /**
      * Instantiate a {@link Jaguar}.
@@ -70,11 +95,7 @@ public class Jaguar implements SpectrumEval {
             final CoverageController controller,
             final SpectrumExporter exporter,
             final Heuristic heuristic) {
-        this.controller = controller;
-        this.exporter = exporter;
-        this.heuristic = heuristic;
-        failedTests = 0;
-        passedTests = 0;
+        this(controller, exporter, heuristic, false);
     }
 
     /**
@@ -91,10 +112,16 @@ public class Jaguar implements SpectrumEval {
      *
      * The current implementation reset runtime code coverage data as no
      * code executed so far is related to current test.
+     *
+     * @throws IOException in case of exceptions during dump.
      */
-    public void testStarted() {
+    public void testStarted() throws IOException {
         if (controller != null) {
-            controller.reset();
+            if (noDump) {
+                controller.reset();
+            } else {
+                controller.dump(true);
+            }
         }
     }
 

--- a/jaguar2-core/src/test/java/br/usp/each/saeg/jaguar2/core/JaguarTest.java
+++ b/jaguar2-core/src/test/java/br/usp/each/saeg/jaguar2/core/JaguarTest.java
@@ -16,6 +16,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import java.io.IOException;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -57,7 +59,19 @@ public class JaguarTest {
     }
 
     @Test
-    public void testStartedCallControllerReset() {
+    public void testStartedCallControllerDump() throws IOException {
+        // When
+        jaguar.testStarted();
+
+        // Then
+        verify(controllerMock, times(1)).dump(true);
+    }
+
+    @Test
+    public void testStartedCallControllerResetWhenNoDump() throws IOException {
+        // Given
+        jaguar = new Jaguar(controllerMock, exporterMock, heuristicMock, true);
+
         // When
         jaguar.testStarted();
 

--- a/jaguar2-examples/jaguar2-example-junit4-jacoco/pom.xml
+++ b/jaguar2-examples/jaguar2-example-junit4-jacoco/pom.xml
@@ -33,6 +33,12 @@
 							<goal>prepare-agent</goal>
 						</goals>
 					</execution>
+					<execution>
+						<id>report</id>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
 				</executions>
 			</plugin>
 			<plugin>

--- a/jaguar2-junit4/src/main/java/br/usp/each/saeg/jaguar2/junit/JaguarJUnitRunListener.java
+++ b/jaguar2-junit4/src/main/java/br/usp/each/saeg/jaguar2/junit/JaguarJUnitRunListener.java
@@ -10,6 +10,8 @@
  */
 package br.usp.each.saeg.jaguar2.junit;
 
+import java.io.IOException;
+
 import org.junit.runner.Description;
 import org.junit.runner.Result;
 import org.junit.runner.notification.Failure;
@@ -31,6 +33,11 @@ import br.usp.each.saeg.jaguar2.spi.SpectrumExporter;
  * Jaguar will got this information when test finishes.
  */
 public class JaguarJUnitRunListener extends RunListener {
+
+    /**
+     * Name of the property that allows enable no dump feature.
+     */
+    public static final String JAGUAR2_NO_DUMP = "jaguar2.noDump";
 
     private final Jaguar jaguar;
 
@@ -73,7 +80,8 @@ public class JaguarJUnitRunListener extends RunListener {
         this(new Jaguar(
                 new CoverageControllerLoader().load(),
                 new SpectrumExporterLoader().load(),
-                new Ochiai()));
+                new Ochiai(),
+                Boolean.getBoolean(JAGUAR2_NO_DUMP)));
     }
 
     @Override
@@ -82,7 +90,7 @@ public class JaguarJUnitRunListener extends RunListener {
     }
 
     @Override
-    public void testStarted(final Description description) {
+    public void testStarted(final Description description) throws IOException {
         fail = false;
         skip = false;
         jaguar.testStarted();

--- a/jaguar2-junit4/src/test/java/br/usp/each/saeg/jaguar2/junit/JaguarJUnitRunListenerTest.java
+++ b/jaguar2-junit4/src/test/java/br/usp/each/saeg/jaguar2/junit/JaguarJUnitRunListenerTest.java
@@ -10,10 +10,13 @@
  */
 package br.usp.each.saeg.jaguar2.junit;
 
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
+
+import java.io.IOException;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -288,8 +291,12 @@ public class JaguarJUnitRunListenerTest {
 
             @Override
             public void run() {
-                inOrder.verify(jaguarMock, times(2)).testStarted();
-                inOrder.verify(jaguarMock).testFinished(eq(false));
+                try {
+                    inOrder.verify(jaguarMock, times(2)).testStarted();
+                    inOrder.verify(jaguarMock).testFinished(eq(false));
+                } catch (final IOException e) {
+                    fail();
+                }
             }
 
         });
@@ -313,8 +320,12 @@ public class JaguarJUnitRunListenerTest {
 
             @Override
             public void run() {
-                inOrder.verify(jaguarMock, times(2)).testStarted();
-                inOrder.verify(jaguarMock).testFinished(eq(true));
+                try {
+                    inOrder.verify(jaguarMock, times(2)).testStarted();
+                    inOrder.verify(jaguarMock).testFinished(eq(true));
+                } catch (final IOException e) {
+                    fail();
+                }
             }
 
         });
@@ -338,7 +349,11 @@ public class JaguarJUnitRunListenerTest {
 
             @Override
             public void run() {
-                inOrder.verify(jaguarMock, times(2)).testStarted();
+                try {
+                    inOrder.verify(jaguarMock, times(2)).testStarted();
+                } catch (final IOException e) {
+                    fail();
+                }
             }
 
         });
@@ -353,25 +368,37 @@ public class JaguarJUnitRunListenerTest {
     }
 
     private void successTest() {
-        final Description desc = mock(Description.class);
-        listener.testStarted(desc);
-        listener.testFinished(desc);
+        try {
+            final Description desc = mock(Description.class);
+            listener.testStarted(desc);
+            listener.testFinished(desc);
+        } catch (final IOException e) {
+            fail();
+        }
     }
 
     private void failTest() {
-        final Description desc = mock(Description.class);
-        final Failure failure = mock(Failure.class);
-        listener.testStarted(desc);
-        listener.testFailure(failure);
-        listener.testFinished(desc);
+        try {
+            final Description desc = mock(Description.class);
+            final Failure failure = mock(Failure.class);
+            listener.testStarted(desc);
+            listener.testFailure(failure);
+            listener.testFinished(desc);
+        } catch (final IOException e) {
+            fail();
+        }
     }
 
     private void assumptionFailureTest() {
-        final Description desc = mock(Description.class);
-        final Failure failure = mock(Failure.class);
-        listener.testStarted(desc);
-        listener.testAssumptionFailure(failure);
-        listener.testFinished(desc);
+        try {
+            final Description desc = mock(Description.class);
+            final Failure failure = mock(Failure.class);
+            listener.testStarted(desc);
+            listener.testAssumptionFailure(failure);
+            listener.testFinished(desc);
+        } catch (final IOException e) {
+            fail();
+        }
     }
 
     private void verifyTests(final Runnable runnable) throws Exception {
@@ -382,17 +409,29 @@ public class JaguarJUnitRunListenerTest {
     }
 
     private void verifySuccessTest() {
-        inOrder.verify(jaguarMock).testStarted();
-        inOrder.verify(jaguarMock).testFinished(eq(false));
+        try {
+            inOrder.verify(jaguarMock).testStarted();
+            inOrder.verify(jaguarMock).testFinished(eq(false));
+        } catch (final IOException e) {
+            fail();
+        }
     }
 
     private void verifyFailTest() {
-        inOrder.verify(jaguarMock).testStarted();
-        inOrder.verify(jaguarMock).testFinished(eq(true));
+        try {
+            inOrder.verify(jaguarMock).testStarted();
+            inOrder.verify(jaguarMock).testFinished(eq(true));
+        } catch (final IOException e) {
+            fail();
+        }
     }
 
     private void verifyAssumptionFailure() {
-        inOrder.verify(jaguarMock).testStarted();
+        try {
+            inOrder.verify(jaguarMock).testStarted();
+        } catch (final IOException e) {
+            fail();
+        }
     }
 
 }

--- a/jaguar2-providers/jaguar2-ba-dua-provider/src/main/java/br/usp/each/saeg/jaguar2/badua/BaDuaController.java
+++ b/jaguar2-providers/jaguar2-ba-dua-provider/src/main/java/br/usp/each/saeg/jaguar2/badua/BaDuaController.java
@@ -68,6 +68,11 @@ public class BaDuaController implements CoverageController {
     }
 
     @Override
+    public void dump(final boolean reset) throws IOException {
+        agent.dump(reset);
+    }
+
+    @Override
     public void save(final boolean testFailed) {
         /*
          * BA-DUA's execution data.

--- a/jaguar2-providers/jaguar2-jacoco-provider/src/main/java/br/usp/each/saeg/jaguar2/jacoco/JaCoCoController.java
+++ b/jaguar2-providers/jaguar2-jacoco-provider/src/main/java/br/usp/each/saeg/jaguar2/jacoco/JaCoCoController.java
@@ -79,6 +79,11 @@ public class JaCoCoController extends ClassFilesController implements CoverageCo
     }
 
     @Override
+    public void dump(final boolean reset) throws IOException {
+        agent.dump(reset);
+    }
+
+    @Override
     public void save(final boolean testFailed) {
         /*
          * JaCoCo's execution data.

--- a/jaguar2-validations/pom.xml
+++ b/jaguar2-validations/pom.xml
@@ -25,6 +25,7 @@
 		<license.header.fileLocation>../LICENSE-TEMPLATE.txt</license.header.fileLocation>
 		<maven.deploy.skip>true</maven.deploy.skip>
 		<gpg.skip>true</gpg.skip>
+		<maven.install.skip>true</maven.install.skip>
 	</properties>
 
 	<build>

--- a/jaguar2-validations/pom.xml
+++ b/jaguar2-validations/pom.xml
@@ -24,6 +24,7 @@
 	<properties>
 		<license.header.fileLocation>../LICENSE-TEMPLATE.txt</license.header.fileLocation>
 		<maven.deploy.skip>true</maven.deploy.skip>
+		<gpg.skip>true</gpg.skip>
 	</properties>
 
 	<build>

--- a/jaguar2-validations/pom.xml
+++ b/jaguar2-validations/pom.xml
@@ -20,7 +20,6 @@
 	</parent>
 
 	<artifactId>jaguar2-validations</artifactId>
-	<packaging>pom</packaging>
 
 	<properties>
 		<license.header.fileLocation>../LICENSE-TEMPLATE.txt</license.header.fileLocation>

--- a/jaguar2-validations/pom.xml
+++ b/jaguar2-validations/pom.xml
@@ -27,6 +27,17 @@
 	</properties>
 
 	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-jar-plugin</artifactId>
+					<configuration>
+						<skipIfEmpty>true</skipIfEmpty>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/jaguar2-validations/src/test/java/TestVerifyDump.java
+++ b/jaguar2-validations/src/test/java/TestVerifyDump.java
@@ -1,0 +1,48 @@
+
+/**
+ * Copyright (c) 2021, 2021 University of Sao Paulo and Contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Roberto Araujo - initial API and implementation and/or initial documentation
+ */
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+
+import javax.xml.stream.XMLEventReader;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.events.StartElement;
+import javax.xml.stream.events.XMLEvent;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestVerifyDump {
+
+    @Test
+    public void verify() throws XMLStreamException, FileNotFoundException {
+        final XMLEventReader reader = XMLInputFactory.newInstance().createXMLEventReader(
+            new FileInputStream(
+                "../jaguar2-examples/jaguar2-example-junit4-jacoco/target/site/jacoco/jacoco.xml"
+            )
+        );
+
+        int sessions = 0;
+        while (reader.hasNext()) {
+            final XMLEvent nextEvent = reader.nextEvent();
+            if (nextEvent.isStartElement()) {
+                final StartElement startElement = nextEvent.asStartElement();
+                if (startElement.getName().getLocalPart().equals("sessioninfo")) {
+                    sessions++;
+                }
+            }
+        }
+
+        Assert.assertEquals(6, sessions);
+    }
+
+}


### PR DESCRIPTION
the old reset-only behavior can be enabled with `jaguar2.noDump` system property with value true 