### PR TITLE
Add Jaguar2 Build to Jaguar2 Parent Modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,7 @@
 	</properties>
 
 	<modules>
+		<module>jaguar2-build</module>
 		<module>jaguar2-api</module>
 		<module>jaguar2-core</module>
 		<module>jaguar2-commons</module>


### PR DESCRIPTION
So we can deploy it from Jaguar2 Parent.

Note that Jaguar2 Build is used as parent of `jaguar2-parent` so good idea to also deploy it to Maven Central.