### PR TITLE
Move Maven required config for deploy to Jaguar2 Build

### DIFF
--- a/jaguar2-build/pom.xml
+++ b/jaguar2-build/pom.xml
@@ -17,6 +17,59 @@
 	<artifactId>jaguar2-build</artifactId>
 	<version>0.0.2-SNAPSHOT</version>
 	<packaging>pom</packaging>
+	<name>Jaguar2</name>
+	<url>https://github.com/saeg/jaguar2</url>
+	<description>Jaguar - JAva coveraGe faUlt locAlization Rank</description>
+	<inceptionYear>2021</inceptionYear>
+
+	<organization>
+		<name>University of Sao Paulo</name>
+	</organization>
+
+	<licenses>
+		<license>
+			<name>Eclipse Public License v1.0</name>
+			<url>http://www.eclipse.org/legal/epl-v10.html</url>
+			<distribution>repo</distribution>
+		</license>
+	</licenses>
+
+	<scm>
+		<url>https://github.com/saeg/jaguar2</url>
+		<connection>scm:git:https://github.com/saeg/jaguar2.git</connection>
+		<developerConnection>scm:git:git@github.com:saeg/jaguar2.git</developerConnection>
+		<tag>HEAD</tag>
+	</scm>
+
+	<distributionManagement>
+		<snapshotRepository>
+			<id>ossrh</id>
+			<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+		</snapshotRepository>
+		<repository>
+			<id>ossrh</id>
+			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+		</repository>
+	</distributionManagement>
+
+	<issueManagement>
+		<system>GitHub Issues</system>
+		<url>https://github.com/saeg/jaguar2/issues</url>
+	</issueManagement>
+
+	<ciManagement>
+		<system>GitHub Actions</system>
+		<url>https://github.com/saeg/jaguar2/actions</url>
+	</ciManagement>
+
+	<developers>
+		<developer>
+			<email>roberto.andrioli@gmail.com</email>
+			<name>Roberto Araujo</name>
+			<url>https://github.com/andrioli</url>
+			<id>andrioli</id>
+		</developer>
+	</developers>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -24,59 +24,6 @@
 	<artifactId>jaguar2-parent</artifactId>
 	<version>0.0.2-SNAPSHOT</version>
 	<packaging>pom</packaging>
-	<name>jaguar2-parent</name>
-	<url>https://github.com/saeg/jaguar2</url>
-	<description>Jaguar - JAva coveraGe faUlt locAlization Rank</description>
-	<inceptionYear>2021</inceptionYear>
-
-	<organization>
-		<name>University of Sao Paulo</name>
-	</organization>
-
-	<licenses>
-		<license>
-			<name>Eclipse Public License v1.0</name>
-			<url>http://www.eclipse.org/legal/epl-v10.html</url>
-			<distribution>repo</distribution>
-		</license>
-	</licenses>
-
-	<scm>
-		<url>https://github.com/saeg/jaguar2</url>
-		<connection>scm:git:https://github.com/saeg/jaguar2.git</connection>
-		<developerConnection>scm:git:git@github.com:saeg/jaguar2.git</developerConnection>
-		<tag>HEAD</tag>
-	</scm>
-
-	<distributionManagement>
-		<snapshotRepository>
-			<id>ossrh</id>
-			<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-		</snapshotRepository>
-		<repository>
-			<id>ossrh</id>
-			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-		</repository>
-	</distributionManagement>
-
-	<issueManagement>
-		<system>GitHub Issues</system>
-		<url>https://github.com/saeg/jaguar2/issues</url>
-	</issueManagement>
-
-	<ciManagement>
-		<system>GitHub Actions</system>
-		<url>https://github.com/saeg/jaguar2/actions</url>
-	</ciManagement>
-
-	<developers>
-		<developer>
-			<email>roberto.andrioli@gmail.com</email>
-			<name>Roberto Araujo</name>
-			<url>https://github.com/andrioli</url>
-			<id>andrioli</id>
-		</developer>
-	</developers>
 
 	<properties>
 		<license.header.fileLocation>LICENSE-TEMPLATE.txt</license.header.fileLocation>


### PR DESCRIPTION
Actually, I was trying to deploy v0.0.2 but got one error:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-deploy-plugin:3.1.1:deploy (default-deploy) on project jaguar2-build: Deployment failed: repository element was not specified in the POM inside distributionManagement element or in -DaltDeploymentRepository=id::url parameter -> [Help 1]
```

That is obvious. 

Note that we want to deploy `jaguar2-build` (#82) but this module does not inherit Jaguar2 Parent (`jaguar2-parent`) that includes all required configurations to deploy on Maven Central. That's why we are moving all Maven required configs for deploy from Jaguar2 Parent to Jaguar2 Build.

Maybe good idea to add deploy stage on CI (even for snapshot only) so we will caught  this kind of problems during development and not during the release.