### PR TITLE
Update Mockito (`mockito-core`) 1.10.19 -> 2.28.2

### DIFF
--- a/jaguar2-core/src/test/java/br/usp/each/saeg/jaguar2/core/JaguarEvalTest.java
+++ b/jaguar2-core/src/test/java/br/usp/each/saeg/jaguar2/core/JaguarEvalTest.java
@@ -19,7 +19,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import br.usp.each.saeg.jaguar2.api.Heuristic;
 import br.usp.each.saeg.jaguar2.api.ILineSpectrum;

--- a/jaguar2-core/src/test/java/br/usp/each/saeg/jaguar2/core/JaguarTest.java
+++ b/jaguar2-core/src/test/java/br/usp/each/saeg/jaguar2/core/JaguarTest.java
@@ -10,7 +10,7 @@
  */
 package br.usp.each.saeg.jaguar2.core;
 
-import static org.mockito.Matchers.same;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -23,7 +23,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import br.usp.each.saeg.jaguar2.api.Heuristic;
 import br.usp.each.saeg.jaguar2.api.IBundleSpectrum;

--- a/jaguar2-junit4/src/test/java/br/usp/each/saeg/jaguar2/junit/JaguarJUnitRunListenerTest.java
+++ b/jaguar2-junit4/src/test/java/br/usp/each/saeg/jaguar2/junit/JaguarJUnitRunListenerTest.java
@@ -11,7 +11,7 @@
 package br.usp.each.saeg.jaguar2.junit;
 
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -26,7 +26,7 @@ import org.junit.runner.RunWith;
 import org.junit.runner.notification.Failure;
 import org.mockito.InOrder;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import br.usp.each.saeg.jaguar2.core.Jaguar;
 

--- a/pom.xml
+++ b/pom.xml
@@ -236,7 +236,7 @@
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
-			<version>1.10.19</version>
+			<version>2.28.2</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -254,16 +254,6 @@
 			</properties>
 		</profile>
 		<profile>
-			<id>mockito-add-opens</id>
-			<activation>
-				<!-- Required only for Java >= 16 -->
-				<jdk>[16,)</jdk>
-			</activation>
-			<properties>
-				<argLine>--add-opens=java.base/java.lang=ALL-UNNAMED</argLine>
-			</properties>
-		</profile>
-		<profile>
 			<id>animal-sniffer-bytecode-java21</id>
 			<activation>
 				<property>


### PR DESCRIPTION
This is the latest release of Mockito 2 and the latest version that can run on Java 6.

See: https://github.com/mockito/mockito/wiki/What%27s-new-in-Mockito-2
See: https://github.com/mockito/mockito/blob/release/2.x/doc/release-notes/official.md

Fortunately, there is no breaking API changes. Just a few classes that was deprecated in favor of new classes in different packages, but with the same API.

---

fix #90