### PR TITLE
Upgrade Apache Maven PMD Plugin 3.13.0 -> 3.21.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@
   * JaCoCo updated from 0.8.7 to 0.8.9;
   * ~~Build with JDK >= 16 opens `java.base/java.lang` to unnamed module;~~ (Reverted by [#92](https://github.com/saeg/jaguar2/pull/92))
   * Build targeting Java 21 bytecode version skips Animal Sniffer Maven Plugin.
+* Update Apache Maven PMD Plugin to 3.21.2 (
+  [#93](https://github.com/saeg/jaguar2/pull/93)
+).
 
 ### [v0.0.2](https://github.com/saeg/jaguar2/releases/tag/v0.0.2)
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
 
 	<properties>
 		<license.header.fileLocation>LICENSE-TEMPLATE.txt</license.header.fileLocation>
+		<maven-pmd-plugin.version>3.21.2</maven-pmd-plugin.version>
 	</properties>
 
 	<modules>
@@ -162,7 +163,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-pmd-plugin</artifactId>
-				<version>3.21.2</version>
+				<version>${maven-pmd-plugin.version}</version>
 				<configuration>
 					<verbose>true</verbose>
 				</configuration>
@@ -263,6 +264,18 @@
 			</activation>
 			<properties>
 				<animal.sniffer.skip>true</animal.sniffer.skip>
+			</properties>
+		</profile>
+		<profile>
+			<id>toolchain-jdk7-versions</id>
+			<activation>
+				<property>
+					<name>jdk</name>
+					<value>7</value>
+				</property>
+			</activation>
+			<properties>
+				<maven-pmd-plugin.version>3.14.0</maven-pmd-plugin.version>
 			</properties>
 		</profile>
 	</profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-pmd-plugin</artifactId>
-				<version>3.13.0</version>
+				<version>3.21.2</version>
 				<configuration>
 					<verbose>true</verbose>
 				</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -275,7 +275,7 @@
 				</property>
 			</activation>
 			<properties>
-				<maven-pmd-plugin.version>3.14.0</maven-pmd-plugin.version>
+				<maven-pmd-plugin.version>3.13.0</maven-pmd-plugin.version>
 			</properties>
 		</profile>
 	</profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -267,6 +267,18 @@
 			</properties>
 		</profile>
 		<profile>
+			<id>toolchain-jdk6-versions</id>
+			<activation>
+				<property>
+					<name>jdk</name>
+					<value>6</value>
+				</property>
+			</activation>
+			<properties>
+				<maven-pmd-plugin.version>3.13.0</maven-pmd-plugin.version>
+			</properties>
+		</profile>
+		<profile>
 			<id>toolchain-jdk7-versions</id>
 			<activation>
 				<property>


### PR DESCRIPTION
Update Apache Maven PMD Plugin to 3.21.2. Using version 3.13.0 when running with JDK 6/7 toolchain!

---

fix #76

partially fix #89