### PR TITLE
Disable PMD type resolution when targeting Java 21 bytecode

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@
 * Update Apache Maven PMD Plugin to 3.21.2 (
   [#93](https://github.com/saeg/jaguar2/pull/93)
 ).
+* Disable PMD type resolution when targeting Java 21 bytecode (
+  [#94](https://github.com/saeg/jaguar2/pull/94)
+).
 
 ### [v0.0.2](https://github.com/saeg/jaguar2/releases/tag/v0.0.2)
 

--- a/pom.xml
+++ b/pom.xml
@@ -255,7 +255,7 @@
 			</properties>
 		</profile>
 		<profile>
-			<id>animal-sniffer-bytecode-java21</id>
+			<id>bytecode-java21</id>
 			<activation>
 				<property>
 					<name>bytecode</name>
@@ -264,6 +264,7 @@
 			</activation>
 			<properties>
 				<animal.sniffer.skip>true</animal.sniffer.skip>
+				<pmd.typeResolution>false</pmd.typeResolution>
 			</properties>
 		</profile>
 		<profile>


### PR DESCRIPTION
See: https://maven.apache.org/plugins/maven-pmd-plugin/pmd-mojo.html#typeResolution
See: https://maven.apache.org/plugins/maven-pmd-plugin/examples/targetJdk.html#using-maven-toolchains

Otherwise, the PMD will fail with the folling exception:

```
 net.sourceforge.pmd.PMDException: Error while processing ClassFile.java
	at net.sourceforge.pmd.SourceCodeProcessor.processSourceCodeWithoutCache(SourceCodeProcessor.java:128)
	at net.sourceforge.pmd.SourceCodeProcessor.processSourceCode(SourceCodeProcessor.java:100)
	at net.sourceforge.pmd.SourceCodeProcessor.processSourceCode(SourceCodeProcessor.java:62)
	at net.sourceforge.pmd.processor.PmdRunnable.call(PmdRunnable.java:89)
	at net.sourceforge.pmd.processor.PmdRunnable.call(PmdRunnable.java:30)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: java.lang.IllegalArgumentException: Unsupported class file major version 65
	at org.objectweb.asm.ClassReader.<init>(ClassReader.java:199)
	at org.objectweb.asm.ClassReader.<init>(ClassReader.java:180)
	at org.objectweb.asm.ClassReader.<init>(ClassReader.java:166)
	at org.objectweb.asm.ClassReader.<init>(ClassReader.java:287)
	at net.sourceforge.pmd.lang.java.typeresolution.PMDASMClassLoader.getImportedClasses(PMDASMClassLoader.java:118)
	at net.sourceforge.pmd.lang.java.typeresolution.ClassTypeResolver.populateClassName(ClassTypeResolver.java:1643)
	at net.sourceforge.pmd.lang.java.typeresolution.ClassTypeResolver.visit(ClassTypeResolver.java:216)
	at net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit.jjtAccept(ASTCompilationUnit.java:44)
	at net.sourceforge.pmd.lang.java.typeresolution.TypeResolutionFacade.initializeWith(TypeResolutionFacade.java:21)
	at net.sourceforge.pmd.lang.java.AbstractJavaHandler$5.start(AbstractJavaHandler.java:121)
	at net.sourceforge.pmd.SourceCodeProcessor.usesTypeResolution(SourceCodeProcessor.java:178)
	at net.sourceforge.pmd.SourceCodeProcessor.processSource(SourceCodeProcessor.java:205)
	at net.sourceforge.pmd.SourceCodeProcessor.processSourceCodeWithoutCache(SourceCodeProcessor.java:118)
	... 10 more
```

But the build will be green.

---

fix #89