### PR TITLE
Fix error building Jaguar with Java 9/10 and using JDK Toolchain 6/7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,3 +42,36 @@ jobs:
     - name: Build
       if: ${{ matrix.java < 8 }}
       run: ./mvnw install -Prelease -Djdk=${{ matrix.java }} -Dbytecode=${{ matrix.java }}
+
+  issue-80:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04]
+        java: [9, 10]
+        jdk: [6, 7]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup JDK toolchain
+      uses: actions/setup-java@v3
+      with:
+        distribution: zulu
+        java-version: ${{ matrix.jdk }}
+        java-package: jdk
+        cache: maven
+        mvn-toolchain-id: ${{ matrix.jdk }}
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        distribution: zulu
+        java-version: ${{ matrix.java }}
+        java-package: jdk
+    - name: Setup GPG
+      run: gpg --batch --passphrase '' --quick-gen-key "John Doe <johndoe@x.y>" ed25519 sign 1d
+    - name: Available toolchains
+      run: cat $HOME/.m2/toolchains.xml
+    - name: Java version
+      run: java -version && javac -version
+    - name: Build
+      run: ./mvnw install -Prelease -Djdk=${{ matrix.jdk }} -Dbytecode=${{ matrix.jdk }}

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@
 * Disable PMD type resolution when targeting Java 21 bytecode (
   [#94](https://github.com/saeg/jaguar2/pull/94)
 ).
+* Fix invalid `-html5` Javadoc option when building with Java 9 or 10 and using JDK Toolchain 6 or 7 (
+  [#96](https://github.com/saeg/jaguar2/pull/96)
+).
 
 ### [v0.0.2](https://github.com/saeg/jaguar2/releases/tag/v0.0.2)
 

--- a/jaguar2-build/pom.xml
+++ b/jaguar2-build/pom.xml
@@ -226,11 +226,10 @@
 			<properties>
 				<!--
 					overrides properties possibly defined by
-					jdk12, jdk20 or html5-javadoc profiles
+					jdk12 and jdk20 profiles
 				-->
 				<source>1.6</source>
 				<bytecode>1.6</bytecode>
-				<additionalJOption />
 			</properties>
 		</profile>
 		<profile>
@@ -244,11 +243,10 @@
 			<properties>
 				<!--
 					overrides properties possibly defined by
-					jdk12, jdk20 or html5-javadoc profiles
+					jdk12 and jdk20 profiles
 				-->
 				<source>1.6</source>
 				<bytecode>1.6</bytecode>
-				<additionalJOption />
 			</properties>
 		</profile>
 		<profile>

--- a/pom.xml
+++ b/pom.xml
@@ -268,7 +268,7 @@
 			</properties>
 		</profile>
 		<profile>
-			<id>toolchain-jdk6-versions</id>
+			<id>toolchain-jdk6-parent</id>
 			<activation>
 				<property>
 					<name>jdk</name>
@@ -276,11 +276,12 @@
 				</property>
 			</activation>
 			<properties>
+				<additionalJOption />
 				<maven-pmd-plugin.version>3.13.0</maven-pmd-plugin.version>
 			</properties>
 		</profile>
 		<profile>
-			<id>toolchain-jdk7-versions</id>
+			<id>toolchain-jdk7-parent</id>
 			<activation>
 				<property>
 					<name>jdk</name>
@@ -288,6 +289,7 @@
 				</property>
 			</activation>
 			<properties>
+				<additionalJOption />
 				<maven-pmd-plugin.version>3.13.0</maven-pmd-plugin.version>
 			</properties>
 		</profile>


### PR DESCRIPTION
fix #80 