### PR TITLE
Remove duplicate groupId/version of parent POM

### DIFF
--- a/jaguar2-examples/pom.xml
+++ b/jaguar2-examples/pom.xml
@@ -20,9 +20,7 @@
 		<relativePath>../jaguar2-build/pom.xml</relativePath>
 	</parent>
 
-	<groupId>br.usp.each.saeg</groupId>
 	<artifactId>jaguar2-examples</artifactId>
-	<version>0.0.3-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -20,9 +20,7 @@
 		<relativePath>./jaguar2-build/pom.xml</relativePath>
 	</parent>
 
-	<groupId>br.usp.each.saeg</groupId>
 	<artifactId>jaguar2-parent</artifactId>
-	<version>0.0.3-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<scm>


### PR DESCRIPTION
In PR #79 the Jaguar2 Build module was introduced and those configurations were duplicated.