### PR TITLE
Add test name context to Jaguar2

### DIFF
--- a/jaguar2-api/src/main/java/br/usp/each/saeg/jaguar2/spi/CoverageController.java
+++ b/jaguar2-api/src/main/java/br/usp/each/saeg/jaguar2/spi/CoverageController.java
@@ -43,10 +43,11 @@ public interface CoverageController {
      * Save runtime code coverage data for further analysis. The data is
      * flagged when executed by a failing test case.
      *
+     * @param name       a user-understandable name for the data.
      * @param testFailed a flag indicating that code coverage data are
      *                   executed by a failing test case.
      */
-    void save(boolean testFailed);
+    void save(String name, boolean testFailed);
 
     /**
      * Analyze the saved runtime code coverage data.

--- a/jaguar2-core/src/main/java/br/usp/each/saeg/jaguar2/core/Jaguar.java
+++ b/jaguar2-core/src/main/java/br/usp/each/saeg/jaguar2/core/Jaguar.java
@@ -24,7 +24,8 @@ import br.usp.each.saeg.jaguar2.spi.SpectrumExporter;
  *
  * An instance of this class is notified of events of the underlying
  * test framework by method calls {@link Jaguar#testRunStarted()},
- * {@link Jaguar#testStarted()}, {@link Jaguar#testRunFinished()} and
+ * {@link Jaguar#testStarted(String)},
+ * {@link Jaguar#testFinished(String, boolean)} and
  * {@link Jaguar#testRunFinished()}.
  *
  * By those method calls, the instance will interact with the
@@ -113,9 +114,11 @@ public class Jaguar implements SpectrumEval {
      * The current implementation reset runtime code coverage data as no
      * code executed so far is related to current test.
      *
+     * @param name a user-understandable name for the started test.
+     *
      * @throws IOException in case of exceptions during dump.
      */
-    public void testStarted() throws IOException {
+    public void testStarted(final String name) throws IOException {
         if (controller != null) {
             if (noDump) {
                 controller.reset();
@@ -133,11 +136,12 @@ public class Jaguar implements SpectrumEval {
      * further analysis. The data is flagged when executed by a failing
      * test case.
      *
+     * @param name       a user-understandable name for the finished test.
      * @param testFailed a flag indicating that test fails.
      */
-    public void testFinished(final boolean testFailed) {
+    public void testFinished(final String name, final boolean testFailed) {
         if (controller != null) {
-            controller.save(testFailed);
+            controller.save(name, testFailed);
         }
         if (testFailed) {
             failedTests++;

--- a/jaguar2-junit4/src/main/java/br/usp/each/saeg/jaguar2/junit/JaguarJUnitRunListener.java
+++ b/jaguar2-junit4/src/main/java/br/usp/each/saeg/jaguar2/junit/JaguarJUnitRunListener.java
@@ -93,13 +93,13 @@ public class JaguarJUnitRunListener extends RunListener {
     public void testStarted(final Description description) throws IOException {
         fail = false;
         skip = false;
-        jaguar.testStarted();
+        jaguar.testStarted(description.getDisplayName());
     }
 
     @Override
     public void testFinished(final Description description) {
         if (!skip) {
-            jaguar.testFinished(fail);
+            jaguar.testFinished(description.getDisplayName(), fail);
         }
     }
 

--- a/jaguar2-providers/jaguar2-ba-dua-provider/src/main/java/br/usp/each/saeg/jaguar2/badua/BaDuaController.java
+++ b/jaguar2-providers/jaguar2-ba-dua-provider/src/main/java/br/usp/each/saeg/jaguar2/badua/BaDuaController.java
@@ -73,7 +73,7 @@ public class BaDuaController implements CoverageController {
     }
 
     @Override
-    public void save(final boolean testFailed) {
+    public void save(final String name, final boolean testFailed) {
         /*
          * BA-DUA's execution data.
          *

--- a/jaguar2-providers/jaguar2-jacoco-provider/src/main/java/br/usp/each/saeg/jaguar2/jacoco/JaCoCoController.java
+++ b/jaguar2-providers/jaguar2-jacoco-provider/src/main/java/br/usp/each/saeg/jaguar2/jacoco/JaCoCoController.java
@@ -70,6 +70,7 @@ public class JaCoCoController extends ClassFilesController implements CoverageCo
     @Override
     public void init() {
         super.init();
+        agent.setSessionId("bootstrap");
         spectrumBuilder = new SpectrumBuilder();
     }
 
@@ -84,7 +85,12 @@ public class JaCoCoController extends ClassFilesController implements CoverageCo
     }
 
     @Override
-    public void save(final boolean testFailed) {
+    public void save(final String name, final boolean testFailed) {
+        /*
+         * Set current session id with name and test status.
+         */
+        agent.setSessionId((testFailed ? "failed:" : "passed:") + name);
+
         /*
          * JaCoCo's execution data.
          *

--- a/jaguar2-tests/jaguar2-core.tests/src/test/java/br/usp/each/saeg/jaguar2/core/JaguarEvalTest.java
+++ b/jaguar2-tests/jaguar2-core.tests/src/test/java/br/usp/each/saeg/jaguar2/core/JaguarEvalTest.java
@@ -54,7 +54,7 @@ public class JaguarEvalTest {
         when(heuristicMock.eval(0, 0, 0, 1)).thenReturn(expectedValue);
 
         // And
-        jaguar.testFinished(false);
+        jaguar.testFinished("name", false);
 
         // When
         final double value = jaguar.eval(new Spectrum(0, 0));
@@ -72,7 +72,7 @@ public class JaguarEvalTest {
         when(heuristicMock.eval(0, 0, 1, 0)).thenReturn(expectedValue);
 
         // And
-        jaguar.testFinished(false);
+        jaguar.testFinished("name", false);
 
         // When
         final double value = jaguar.eval(new Spectrum(0, 1));
@@ -90,7 +90,7 @@ public class JaguarEvalTest {
         when(heuristicMock.eval(0, 1, 0, 0)).thenReturn(expectedValue);
 
         // And
-        jaguar.testFinished(true);
+        jaguar.testFinished("name", true);
 
         // When
         final double value = jaguar.eval(new Spectrum(0, 0));
@@ -108,7 +108,7 @@ public class JaguarEvalTest {
         when(heuristicMock.eval(1, 0, 0, 0)).thenReturn(expectedValue);
 
         // And
-        jaguar.testFinished(true);
+        jaguar.testFinished("name", true);
 
         // When
         final double value = jaguar.eval(new Spectrum(1, 0));
@@ -126,8 +126,8 @@ public class JaguarEvalTest {
         when(heuristicMock.eval(0, 0, 0, 2)).thenReturn(expectedValue);
 
         // And
-        jaguar.testFinished(false);
-        jaguar.testFinished(false);
+        jaguar.testFinished("name", false);
+        jaguar.testFinished("name", false);
 
         // When
         final double value = jaguar.eval(new Spectrum(0, 0));
@@ -145,8 +145,8 @@ public class JaguarEvalTest {
         when(heuristicMock.eval(0, 0, 1, 1)).thenReturn(expectedValue);
 
         // And
-        jaguar.testFinished(false);
-        jaguar.testFinished(false);
+        jaguar.testFinished("name", false);
+        jaguar.testFinished("name", false);
 
         // When
         final double value = jaguar.eval(new Spectrum(0, 1));
@@ -164,8 +164,8 @@ public class JaguarEvalTest {
         when(heuristicMock.eval(0, 0, 2, 0)).thenReturn(expectedValue);
 
         // And
-        jaguar.testFinished(false);
-        jaguar.testFinished(false);
+        jaguar.testFinished("name", false);
+        jaguar.testFinished("name", false);
 
         // When
         final double value = jaguar.eval(new Spectrum(0, 2));
@@ -183,8 +183,8 @@ public class JaguarEvalTest {
         when(heuristicMock.eval(0, 2, 0, 0)).thenReturn(expectedValue);
 
         // And
-        jaguar.testFinished(true);
-        jaguar.testFinished(true);
+        jaguar.testFinished("name", true);
+        jaguar.testFinished("name", true);
 
         // When
         final double value = jaguar.eval(new Spectrum(0, 0));
@@ -202,8 +202,8 @@ public class JaguarEvalTest {
         when(heuristicMock.eval(1, 1, 0, 0)).thenReturn(expectedValue);
 
         // And
-        jaguar.testFinished(true);
-        jaguar.testFinished(true);
+        jaguar.testFinished("name", true);
+        jaguar.testFinished("name", true);
 
         // When
         final double value = jaguar.eval(new Spectrum(1, 0));
@@ -221,8 +221,8 @@ public class JaguarEvalTest {
         when(heuristicMock.eval(2, 0, 0, 0)).thenReturn(expectedValue);
 
         // And
-        jaguar.testFinished(true);
-        jaguar.testFinished(true);
+        jaguar.testFinished("name", true);
+        jaguar.testFinished("name", true);
 
         // When
         final double value = jaguar.eval(new Spectrum(2, 0));
@@ -240,8 +240,8 @@ public class JaguarEvalTest {
         when(heuristicMock.eval(0, 1, 0, 1)).thenReturn(expectedValue);
 
         // And
-        jaguar.testFinished(false);
-        jaguar.testFinished(true);
+        jaguar.testFinished("name", false);
+        jaguar.testFinished("name", true);
 
         // When
         final double value = jaguar.eval(new Spectrum(0, 0));
@@ -259,8 +259,8 @@ public class JaguarEvalTest {
         when(heuristicMock.eval(1, 0, 0, 1)).thenReturn(expectedValue);
 
         // And
-        jaguar.testFinished(false);
-        jaguar.testFinished(true);
+        jaguar.testFinished("name", false);
+        jaguar.testFinished("name", true);
 
         // When
         final double value = jaguar.eval(new Spectrum(1, 0));
@@ -278,8 +278,8 @@ public class JaguarEvalTest {
         when(heuristicMock.eval(0, 1, 1, 0)).thenReturn(expectedValue);
 
         // And
-        jaguar.testFinished(false);
-        jaguar.testFinished(true);
+        jaguar.testFinished("name", false);
+        jaguar.testFinished("name", true);
 
         // When
         final double value = jaguar.eval(new Spectrum(0, 1));
@@ -297,8 +297,8 @@ public class JaguarEvalTest {
         when(heuristicMock.eval(1, 0, 1, 0)).thenReturn(expectedValue);
 
         // And
-        jaguar.testFinished(false);
-        jaguar.testFinished(true);
+        jaguar.testFinished("name", false);
+        jaguar.testFinished("name", true);
 
         // When
         final double value = jaguar.eval(new Spectrum(1, 1));

--- a/jaguar2-tests/jaguar2-core.tests/src/test/java/br/usp/each/saeg/jaguar2/core/JaguarTest.java
+++ b/jaguar2-tests/jaguar2-core.tests/src/test/java/br/usp/each/saeg/jaguar2/core/JaguarTest.java
@@ -61,7 +61,7 @@ public class JaguarTest {
     @Test
     public void testStartedCallControllerDump() throws IOException {
         // When
-        jaguar.testStarted();
+        jaguar.testStarted("name");
 
         // Then
         verify(controllerMock, times(1)).dump(true);
@@ -73,28 +73,28 @@ public class JaguarTest {
         jaguar = new Jaguar(controllerMock, exporterMock, heuristicMock, true);
 
         // When
-        jaguar.testStarted();
+        jaguar.testStarted("name");
 
         // Then
         verify(controllerMock, times(1)).reset();
     }
 
     @Test
-    public void testFinishSuccessCallControllerResetWithFalse() {
+    public void testFinishSuccessCallControllerSaveWithFalse() {
         // When
-        jaguar.testFinished(false);
+        jaguar.testFinished("name", false);
 
         // Then
-        verify(controllerMock, times(1)).save(false);
+        verify(controllerMock, times(1)).save("name", false);
     }
 
     @Test
-    public void testFinishFailCallControllerResetWithTrue() {
+    public void testFinishFailCallControllerSaveWithTrue() {
         // When
-        jaguar.testFinished(true);
+        jaguar.testFinished("name", true);
 
         // Then
-        verify(controllerMock, times(1)).save(true);
+        verify(controllerMock, times(1)).save("name", true);
     }
 
     @Test
@@ -146,7 +146,7 @@ public class JaguarTest {
     @Test
     public void testFinishSuccessIncrementsPassedTests() {
         // When
-        jaguar.testFinished(false);
+        jaguar.testFinished("name", false);
 
         // Then
         Assert.assertEquals(0, jaguar.getFailedTests());
@@ -156,7 +156,7 @@ public class JaguarTest {
     @Test
     public void testFinishFailIncrementsFailedTests() {
         // When
-        jaguar.testFinished(true);
+        jaguar.testFinished("name", true);
 
         // Then
         Assert.assertEquals(1, jaguar.getFailedTests());
@@ -166,8 +166,8 @@ public class JaguarTest {
     @Test
     public void testFinishSuccessSuccessIncrementsPassedTestsTwoTimes() {
         // When
-        jaguar.testFinished(false);
-        jaguar.testFinished(false);
+        jaguar.testFinished("name", false);
+        jaguar.testFinished("name", false);
 
         // Then
         Assert.assertEquals(0, jaguar.getFailedTests());
@@ -177,8 +177,8 @@ public class JaguarTest {
     @Test
     public void testFinishFailFailIncrementsFailedTestsTwoTimes() {
         // When
-        jaguar.testFinished(true);
-        jaguar.testFinished(true);
+        jaguar.testFinished("name", true);
+        jaguar.testFinished("name", true);
 
         // Then
         Assert.assertEquals(2, jaguar.getFailedTests());
@@ -188,8 +188,8 @@ public class JaguarTest {
     @Test
     public void testFinishSuccessFailIncrementsCountersCorrectly() {
         // When
-        jaguar.testFinished(false);
-        jaguar.testFinished(true);
+        jaguar.testFinished("name", false);
+        jaguar.testFinished("name", true);
 
         // Then
         Assert.assertEquals(1, jaguar.getFailedTests());
@@ -199,8 +199,8 @@ public class JaguarTest {
     @Test
     public void testFinishFailSuccessIncrementsCountersCorrectly() {
         // When
-        jaguar.testFinished(true);
-        jaguar.testFinished(false);
+        jaguar.testFinished("name", true);
+        jaguar.testFinished("name", false);
 
         // Then
         Assert.assertEquals(1, jaguar.getFailedTests());

--- a/jaguar2-tests/jaguar2-junit4.tests/src/test/java/br/usp/each/saeg/jaguar2/junit/JaguarJUnitRunListenerTest.java
+++ b/jaguar2-tests/jaguar2-junit4.tests/src/test/java/br/usp/each/saeg/jaguar2/junit/JaguarJUnitRunListenerTest.java
@@ -11,10 +11,8 @@
 package br.usp.each.saeg.jaguar2.junit;
 
 import static org.junit.Assert.fail;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 
 import java.io.IOException;
 
@@ -55,7 +53,7 @@ public class JaguarJUnitRunListenerTest {
 
             @Override
             public void run() {
-                successTest();
+                successTest("Class", "test1");
             }
 
         });
@@ -65,7 +63,7 @@ public class JaguarJUnitRunListenerTest {
 
             @Override
             public void run() {
-                verifySuccessTest();
+                verifySuccessTest("Class", "test1");
             }
 
         });
@@ -78,7 +76,7 @@ public class JaguarJUnitRunListenerTest {
 
             @Override
             public void run() {
-                failTest();
+                failTest("Class", "test1");
             }
 
         });
@@ -88,7 +86,7 @@ public class JaguarJUnitRunListenerTest {
 
             @Override
             public void run() {
-                verifyFailTest();
+                verifyFailTest("Class", "test1");
             }
 
         });
@@ -101,7 +99,7 @@ public class JaguarJUnitRunListenerTest {
 
             @Override
             public void run() {
-                assumptionFailureTest();
+                assumptionFailureTest("Class", "test1");
             }
 
         });
@@ -111,7 +109,7 @@ public class JaguarJUnitRunListenerTest {
 
             @Override
             public void run() {
-                verifyAssumptionFailure();
+                verifyAssumptionFailure("Class", "test1");
             }
 
         });
@@ -126,8 +124,8 @@ public class JaguarJUnitRunListenerTest {
 
             @Override
             public void run() {
-                successTest();
-                successTest();
+                successTest("Class", "test1");
+                successTest("Class", "test2");
             }
 
         });
@@ -137,8 +135,8 @@ public class JaguarJUnitRunListenerTest {
 
             @Override
             public void run() {
-                verifySuccessTest();
-                verifySuccessTest();
+                verifySuccessTest("Class", "test1");
+                verifySuccessTest("Class", "test2");
             }
 
         });
@@ -151,8 +149,8 @@ public class JaguarJUnitRunListenerTest {
 
             @Override
             public void run() {
-                successTest();
-                failTest();
+                successTest("Class", "test1");
+                failTest("Class", "test2");
             }
 
         });
@@ -162,8 +160,8 @@ public class JaguarJUnitRunListenerTest {
 
             @Override
             public void run() {
-                verifySuccessTest();
-                verifyFailTest();
+                verifySuccessTest("Class", "test1");
+                verifyFailTest("Class", "test2");
             }
 
         });
@@ -176,8 +174,8 @@ public class JaguarJUnitRunListenerTest {
 
             @Override
             public void run() {
-                successTest();
-                assumptionFailureTest();
+                successTest("Class", "test1");
+                assumptionFailureTest("Class", "test2");
             }
 
         });
@@ -187,8 +185,8 @@ public class JaguarJUnitRunListenerTest {
 
             @Override
             public void run() {
-                verifySuccessTest();
-                verifyAssumptionFailure();
+                verifySuccessTest("Class", "test1");
+                verifyAssumptionFailure("Class", "test2");
             }
 
         });
@@ -203,8 +201,8 @@ public class JaguarJUnitRunListenerTest {
 
             @Override
             public void run() {
-                failTest();
-                successTest();
+                failTest("Class", "test1");
+                successTest("Class", "test2");
             }
 
         });
@@ -214,8 +212,8 @@ public class JaguarJUnitRunListenerTest {
 
             @Override
             public void run() {
-                verifyFailTest();
-                verifySuccessTest();
+                verifyFailTest("Class", "test1");
+                verifySuccessTest("Class", "test2");
             }
 
         });
@@ -228,8 +226,8 @@ public class JaguarJUnitRunListenerTest {
 
             @Override
             public void run() {
-                failTest();
-                failTest();
+                failTest("Class", "test1");
+                failTest("Class", "test2");
             }
 
         });
@@ -239,8 +237,8 @@ public class JaguarJUnitRunListenerTest {
 
             @Override
             public void run() {
-                verifyFailTest();
-                verifyFailTest();
+                verifyFailTest("Class", "test1");
+                verifyFailTest("Class", "test2");
             }
 
         });
@@ -253,8 +251,8 @@ public class JaguarJUnitRunListenerTest {
 
             @Override
             public void run() {
-                failTest();
-                assumptionFailureTest();
+                failTest("Class", "test1");
+                assumptionFailureTest("Class", "test2");
             }
 
         });
@@ -264,8 +262,8 @@ public class JaguarJUnitRunListenerTest {
 
             @Override
             public void run() {
-                verifyFailTest();
-                verifyAssumptionFailure();
+                verifyFailTest("Class", "test1");
+                verifyAssumptionFailure("Class", "test2");
             }
 
         });
@@ -280,8 +278,8 @@ public class JaguarJUnitRunListenerTest {
 
             @Override
             public void run() {
-                assumptionFailureTest();
-                successTest();
+                assumptionFailureTest("Class", "test1");
+                successTest("Class", "test2");
             }
 
         });
@@ -291,12 +289,8 @@ public class JaguarJUnitRunListenerTest {
 
             @Override
             public void run() {
-                try {
-                    inOrder.verify(jaguarMock, times(2)).testStarted();
-                    inOrder.verify(jaguarMock).testFinished(eq(false));
-                } catch (final IOException e) {
-                    fail();
-                }
+                verifyAssumptionFailure("Class", "test1");
+                verifySuccessTest("Class", "test2");
             }
 
         });
@@ -309,8 +303,8 @@ public class JaguarJUnitRunListenerTest {
 
             @Override
             public void run() {
-                assumptionFailureTest();
-                failTest();
+                assumptionFailureTest("Class", "test1");
+                failTest("Class", "test2");
             }
 
         });
@@ -320,12 +314,8 @@ public class JaguarJUnitRunListenerTest {
 
             @Override
             public void run() {
-                try {
-                    inOrder.verify(jaguarMock, times(2)).testStarted();
-                    inOrder.verify(jaguarMock).testFinished(eq(true));
-                } catch (final IOException e) {
-                    fail();
-                }
+                verifyAssumptionFailure("Class", "test1");
+                verifyFailTest("Class", "test2");
             }
 
         });
@@ -338,8 +328,8 @@ public class JaguarJUnitRunListenerTest {
 
             @Override
             public void run() {
-                assumptionFailureTest();
-                assumptionFailureTest();
+                assumptionFailureTest("Class", "test1");
+                assumptionFailureTest("Class", "test2");
             }
 
         });
@@ -349,11 +339,8 @@ public class JaguarJUnitRunListenerTest {
 
             @Override
             public void run() {
-                try {
-                    inOrder.verify(jaguarMock, times(2)).testStarted();
-                } catch (final IOException e) {
-                    fail();
-                }
+                verifyAssumptionFailure("Class", "test1");
+                verifyAssumptionFailure("Class", "test2");
             }
 
         });
@@ -367,9 +354,9 @@ public class JaguarJUnitRunListenerTest {
         listener.testRunFinished(mock(Result.class));
     }
 
-    private void successTest() {
+    private void successTest(final String className, final String name) {
         try {
-            final Description desc = mock(Description.class);
+            final Description desc = Description.createTestDescription(className, name);
             listener.testStarted(desc);
             listener.testFinished(desc);
         } catch (final IOException e) {
@@ -377,9 +364,9 @@ public class JaguarJUnitRunListenerTest {
         }
     }
 
-    private void failTest() {
+    private void failTest(final String className, final String name) {
         try {
-            final Description desc = mock(Description.class);
+            final Description desc = Description.createTestDescription(className, name);
             final Failure failure = mock(Failure.class);
             listener.testStarted(desc);
             listener.testFailure(failure);
@@ -389,9 +376,9 @@ public class JaguarJUnitRunListenerTest {
         }
     }
 
-    private void assumptionFailureTest() {
+    private void assumptionFailureTest(final String className, final String name) {
         try {
-            final Description desc = mock(Description.class);
+            final Description desc = Description.createTestDescription(className, name);
             final Failure failure = mock(Failure.class);
             listener.testStarted(desc);
             listener.testAssumptionFailure(failure);
@@ -408,27 +395,30 @@ public class JaguarJUnitRunListenerTest {
         inOrder.verifyNoMoreInteractions();
     }
 
-    private void verifySuccessTest() {
+    private void verifySuccessTest(final String className, final String name) {
         try {
-            inOrder.verify(jaguarMock).testStarted();
-            inOrder.verify(jaguarMock).testFinished(eq(false));
+            final String formattedName = String.format("%s(%s)", name, className);
+            inOrder.verify(jaguarMock).testStarted(formattedName);
+            inOrder.verify(jaguarMock).testFinished(formattedName, false);
         } catch (final IOException e) {
             fail();
         }
     }
 
-    private void verifyFailTest() {
+    private void verifyFailTest(final String className, final String name) {
         try {
-            inOrder.verify(jaguarMock).testStarted();
-            inOrder.verify(jaguarMock).testFinished(eq(true));
+            final String formattedName = String.format("%s(%s)", name, className);
+            inOrder.verify(jaguarMock).testStarted(formattedName);
+            inOrder.verify(jaguarMock).testFinished(formattedName, true);
         } catch (final IOException e) {
             fail();
         }
     }
 
-    private void verifyAssumptionFailure() {
+    private void verifyAssumptionFailure(final String className, final String name) {
         try {
-            inOrder.verify(jaguarMock).testStarted();
+            final String formattedName = String.format("%s(%s)", name, className);
+            inOrder.verify(jaguarMock).testStarted(formattedName);
         } catch (final IOException e) {
             fail();
         }

--- a/jaguar2-validations/src/test/java/TestVerifyDump.java
+++ b/jaguar2-validations/src/test/java/TestVerifyDump.java
@@ -49,7 +49,7 @@ public class TestVerifyDump {
         Assert.assertEquals(6, sessions.size());
         Assert.assertTrue(sessions.contains("bootstrap"));
         Assert.assertTrue(sessions.contains("passed:test1(br.usp.each.saeg.jaguar2.MaxTest)"));
-        Assert.assertTrue(sessions.contains("passed:test1(br.usp.each.saeg.jaguar2.MaxTest)"));
+        Assert.assertTrue(sessions.contains("passed:test2(br.usp.each.saeg.jaguar2.MaxTest)"));
         Assert.assertTrue(sessions.contains("passed:test3(br.usp.each.saeg.jaguar2.MaxTest)"));
         Assert.assertTrue(sessions.contains("failed:test4(br.usp.each.saeg.jaguar2.MaxTest)"));
         Assert.assertTrue(sessions.contains("failed:test5(br.usp.each.saeg.jaguar2.MaxTest)"));

--- a/jaguar2-validations/src/test/java/TestVerifyDump.java
+++ b/jaguar2-validations/src/test/java/TestVerifyDump.java
@@ -11,7 +11,10 @@
  */
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.util.ArrayList;
+import java.util.List;
 
+import javax.xml.namespace.QName;
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
@@ -31,18 +34,25 @@ public class TestVerifyDump {
             )
         );
 
-        int sessions = 0;
+        final List<String> sessions = new ArrayList<String>();
+        final QName id = QName.valueOf("id");
         while (reader.hasNext()) {
             final XMLEvent nextEvent = reader.nextEvent();
             if (nextEvent.isStartElement()) {
                 final StartElement startElement = nextEvent.asStartElement();
                 if (startElement.getName().getLocalPart().equals("sessioninfo")) {
-                    sessions++;
+                    sessions.add(startElement.getAttributeByName(id).getValue());
                 }
             }
         }
 
-        Assert.assertEquals(6, sessions);
+        Assert.assertEquals(6, sessions.size());
+        Assert.assertTrue(sessions.contains("bootstrap"));
+        Assert.assertTrue(sessions.contains("passed:test1(br.usp.each.saeg.jaguar2.MaxTest)"));
+        Assert.assertTrue(sessions.contains("passed:test1(br.usp.each.saeg.jaguar2.MaxTest)"));
+        Assert.assertTrue(sessions.contains("passed:test3(br.usp.each.saeg.jaguar2.MaxTest)"));
+        Assert.assertTrue(sessions.contains("failed:test4(br.usp.each.saeg.jaguar2.MaxTest)"));
+        Assert.assertTrue(sessions.contains("failed:test5(br.usp.each.saeg.jaguar2.MaxTest)"));
     }
 
 }


### PR DESCRIPTION
Previously, Jaguar2 only stored coverage information flagged with a test outcome (success or failure) to determine the spectrum suspiciousness. Now we're including the test name so Jaguar2 will have the context of which test succeeded or failed.

This commit modifies the `Jaguar` entry point method signatures, requiring clients to update their code. For example, older versions of the Jaguar2 JUnit4 module are incompatible with this new version.

Additionally, the CoverageController API was also updated, introducing breaking changes that make Jaguar2 Core incompatible with older Jaguar2 Coverage Providers.

For now, we've only updated the Jaguar2 JaCoCo Provider, so each session dump will be named test-outcome:testName(className), as shown in the example below:

```
passed:test1(br.usp.each.saeg.jaguar2.MaxTest)
failed:test4(br.usp.each.saeg.jaguar2.MaxTest)
```